### PR TITLE
Teletortoise: /halt not working

### DIFF
--- a/app/models/remote/workspace/ForeverRunner.scala
+++ b/app/models/remote/workspace/ForeverRunner.scala
@@ -57,7 +57,7 @@ trait ForeverRunner extends HeadlessWorkspace {
   private case object Loop
   private case class SetOutputCallback(callback: (String) => Unit)
 
-  override def halt() {
+  abstract override def halt() {
     runningTasks = ListSet()
     super.halt()
   }

--- a/app/models/remote/workspace/WebWorkspace.scala
+++ b/app/models/remote/workspace/WebWorkspace.scala
@@ -19,3 +19,4 @@ class WebWorkspace(world: World, compiler: CompilerInterface, renderer: Renderer
     with StateTracker
     with Compiler
     with ForeverRunner
+    


### PR DESCRIPTION
To reproduce:
1. Switch to observer
2. `crt 1`
3. `loop [ ask turtles [ fd .1 ] display ]`
4. Switch to chatter
5. `/halt`

Result: The command center says it's halting but the turtles keeps moving
Expected: The turtle stops moving
