### PR TITLE
Too many different colors causes client to crash

### DIFF
--- a/app/assets/javascripts/TortoiseJS/agent/colors.coffee
+++ b/app/assets/javascripts/TortoiseJS/agent/colors.coffee
@@ -43,7 +43,7 @@ cachedNetlogoColors = for colorTimesTen in [0..1400]
   "rgb(#{r}, #{g}, #{b})"
 
 colorArrayToCSS = (array) ->
-  [r,g,b] = array
+  [r,g,b] = array.map(Math.round)
   a = if array.length > 3 then array[3] else 255
   if a < 255
     "rgba(#{r}, #{g}, #{b}, #{a/255})"

--- a/app/assets/javascripts/TortoiseJS/agent/drawshape.coffee
+++ b/app/assets/javascripts/TortoiseJS/agent/drawshape.coffee
@@ -30,17 +30,21 @@ class window.CachingShapeDrawer extends ShapeDrawer
 
   drawShape: (ctx, turtleColor, shapeName) ->
     shapeName = shapeName.toLowerCase()
-    shapeCanvas = @shapeCache[[shapeName, turtleColor]]
+    shapeKey = @shapeKey(shapeName, turtleColor)
+    shapeCanvas = @shapeCache[shapeKey]
     if not shapeCanvas?
       shapeCanvas = document.createElement('canvas')
       shapeCanvas.width = shapeCanvas.height = 300
       shapeCtx = shapeCanvas.getContext('2d')
       @drawRawShape(shapeCtx, turtleColor, shapeName)
-      @shapeCache[[shapeName, turtleColor]] = shapeCanvas
+      @shapeCache[shapeKey] = shapeCanvas
     ctx.translate(.5, -.5)
     ctx.scale(-1/300, 1/300)
     ctx.drawImage(shapeCanvas, 0, 0)
     return
+  
+  shapeKey: (shapeName, turtleColor) ->
+    [shapeName, netlogoColorToCSS(turtleColor)]
 
 setColoring = (ctx, turtleColor, element) ->
   turtleColor = netlogoColorToCSS(turtleColor)


### PR DESCRIPTION
Open `/wolfsheep` or something and throw in:

```
to setup 
  ca
  crt 500
  reset-ticks
end

to go
  ask turtles [
  fd 1
  set color scale-color blue xcor min-pxcor max-pxcor
  ]
  tick
end
```

Click go, and after 10 seconds or so, the page should crash. If you do it again and just check `Object.keys(session.controller.turtleView.drawer.shapeCache)`, you'll find an enormous array with many entries like:

```
 "default,104.92367640184938"
 "default,105.39265087337907"
 "default,104.6981161679109"
 "default,105.07632359815062"
 "default,104.91001957826245"
 "default,105.39975633080763"
 "default,105.16269465723032"
```

The problem here is that in the shape cache, we use color as part of the key. So when we get floating point colors, bad things happen. The solution is to simply drop the fractional part (those don't affect color anyway). Note that rgb colors can have the same problem.
