### PR TITLE
Safari 6.0.5 draws blurry patches with latest renderer. other browsers fine

### DIFF
--- a/app/assets/javascripts/TortoiseJS/agent/view.coffee
+++ b/app/assets/javascripts/TortoiseJS/agent/view.coffee
@@ -147,6 +147,12 @@ class PatchView extends View
     @scratchCanvas.height = @patchHeight
     # Prevents antialiasing when scratchCanvas is stretched and drawn on canvas
     @ctx.imageSmoothingEnabled=false;
+    # Althought imageSmoothingEnabled is in spec, I've seen it break from
+    # version to version in browsers. These browser-specific flags seem to
+    # work more reliably.
+    @ctx.webkitImageSmoothingEnabled = false;
+    @ctx.mozImageSmoothingEnabled = false;
+    @ctx.oImageSmoothingEnabled = false;
     @ctx.fillStyle = 'black'
     @ctx.fillRect(0, 0, @canvas.width, @canvas.height)
 


### PR DESCRIPTION
Safari 6.0.5, Mac OS X 10.8.5:

![screen shot 2013-10-21 at 7 33 41 pm](https://f.cloud.github.com/assets/161079/1377527/6a44880a-3aa9-11e3-8950-ee41f14225e2.png)
