### PR TITLE
Tortoise: use new WidgetParser (no dependence on HeadlessWorkspace)

### DIFF
--- a/app/models/local/NetLogoCompiler.scala
+++ b/app/models/local/NetLogoCompiler.scala
@@ -1,12 +1,14 @@
 package models.local
 
 import
-  org.nlogo.{ api, headless, nvm, shape, tortoise },
+  org.nlogo.{ api, nvm, shape, tortoise, util, workspace },
     api.{ AgentKind, CompilerException, ModelReader, ModelSection, Program, ShapeList, WorldDimensions },
-    headless.WidgetParser,
-    nvm.FrontEndInterface.{ NoProcedures, ProceduresMap },
+    workspace.WidgetParser,
+    nvm.{ DefaultParserServices, FrontEndInterface },
+      FrontEndInterface.{ NoProcedures, ProceduresMap },
     shape.{ LinkShape, VectorShape },
-    tortoise.Compiler
+    tortoise.Compiler,
+    util.Femto
 
 import
   play.api.Logger
@@ -92,7 +94,10 @@ object NetLogoCompiler {
     val turtleShapes = new ShapeList(AgentKind.Turtle, VectorShape.parseShapes(modelMap(ModelSection.TurtleShapes).toArray, version))
     val linkShapes   = new ShapeList(AgentKind.Link,   LinkShape.  parseShapes(modelMap(ModelSection.LinkShapes).  toArray, version))
 
-    val (iGlobals, _, _, _, iGlobalCmds) = new WidgetParser(org.nlogo.headless.HeadlessWorkspace.newInstance).parseWidgets(interface)
+    val (iGlobals, _, _, _, iGlobalCmds) = {
+      val frontEnd = Femto.scalaSingleton[FrontEndInterface]("org.nlogo.compile.front.FrontEnd")
+      new WidgetParser(new DefaultParserServices(frontEnd)).parseWidgets(interface)
+    }
 
     val patchSize = interface(7).toDouble
     val Seq(wrapX, wrapY, _, minX, maxX, minY, maxY) = 14 to 20 map { x => interface(x).toInt }

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -13,8 +13,8 @@ object ApplicationBuild extends Build {
   val appDependencies = Seq(
     "asm" % "asm-all" % "3.3.1", // Necessary evil
     "org.json4s" %% "json4s-native" % "3.1.0",
-    "org.nlogo" % "NetLogoHeadless" % "5.1.0-SNAPSHOT-f7adc38" from
-      "http://ccl.northwestern.edu/devel/NetLogoHeadless-f7adc38.jar",
+    "org.nlogo" % "NetLogoHeadless" % "5.1.0-SNAPSHOT-cb1683c9" from
+      "http://ccl.northwestern.edu/devel/NetLogoHeadless-cb1683c9.jar",
     "org.scalaz" %% "scalaz-core" % "7.0.3",
     "org.webjars" %% "webjars-play" % "2.2.0",
     "org.webjars" % "chosen" % "0.9.12",


### PR DESCRIPTION
at the time you upgrade to the latest NetLogoHeadless to get the latest engine changes, you'll also get the new WidgetParser and need to do this:

``` diff
diff --git a/app/models/local/NetLogoCompiler.scala b/app/models/local/NetLogoCompiler.scala
index e83b350..920937a 100644
--- a/app/models/local/NetLogoCompiler.scala
+++ b/app/models/local/NetLogoCompiler.scala
@@ -1,12 +1,13 @@
 package models.local

 import
-  org.nlogo.{ api, headless, nvm, shape, tortoise },
+  org.nlogo.{ api, nvm, shape, tortoise, workspace },
     api.{ AgentKind, CompilerException, ModelReader, ModelSection, Program, ShapeList, WorldDimensions },
-    headless.WidgetParser,
+    workspace.WidgetParser,
     nvm.FrontEndInterface.{ NoProcedures, ProceduresMap },
     shape.{ LinkShape, VectorShape },
-    tortoise.Compiler
+    tortoise.Compiler,
+    org.nlogo.util.Femto

 import
   play.api.Logger
@@ -92,7 +93,14 @@ object NetLogoCompiler {
     val turtleShapes = new ShapeList(AgentKind.Turtle, VectorShape.parseShapes(modelMap(ModelSection.TurtleShapes).toArray, version))
     val linkShapes   = new ShapeList(AgentKind.Link,   LinkShape.  parseShapes(modelMap(ModelSection.LinkShapes).  toArray, version))

-    val (iGlobals, _, _, _, iGlobalCmds) = new WidgetParser(org.nlogo.headless.HeadlessWorkspace.newInstance).parseWidgets(interface)
+    val (iGlobals, _, _, _, iGlobalCmds) = {
+      val frontEnd: nvm.FrontEndInterface =
+        Femto.scalaSingleton("org.nlogo.compile.front.FrontEnd")
+      val widgetParser =
+        new workspace.WidgetParser(
+          new nvm.DefaultParserServices(frontEnd))
+      widgetParser.parseWidgets(interface)
+    }

     val patchSize = interface(7).toDouble
     val Seq(wrapX, wrapY, _, minX, maxX, minY, maxY) = 14 to 20 map { x => interface(x).toInt }
```
