### PR TITLE
Optimize AgentModel.update for V8

### DIFF
--- a/app/assets/javascripts/TortoiseJS/agent/agentmodel.coffee
+++ b/app/assets/javascripts/TortoiseJS/agent/agentmodel.coffee
@@ -6,13 +6,13 @@ class window.AgentModel
     @observer = {}
     @world = {}
 
-# The loops here have been optimized for V8 by replace for ... of ... loops
-# with regular loops over Object.keys. It would be better if they were
-# for ... of ... loops, but V8 wasn't able to optimize that. Note that this is
-# not a good optimization strategy in general. It only works in specific
-# situations.
-# The bodies of the loops are in inlineable loops. This also helps V8 reason
-# about the loops.
+  # The loops here have been optimized for V8 by replace for ... of ... loops
+  # with regular loops over Object.keys. It would be better if they were
+  # for ... of ... loops, but V8 wasn't able to optimize that. Note that this is
+  # not a good optimization strategy in general. It only works in specific
+  # situations.
+  # The bodies of the loops are in inlineable loops. This also helps V8 reason
+  # about the loops. --BCH (1/9/14)
   update: (modelUpdate) ->
     turtleUpdates = modelUpdate.turtles
     if turtleUpdates
@@ -74,7 +74,7 @@ class window.AgentModel
   mergeObjectInto = (updatedObject, targetObject) ->
     # Chrome complains it can't inline this function. Changing this to a
     # regular for loop over Object.keys fixes this, but actually makes
-    # performance worse.
+    # performance worse. --BCH (1/9/14)
     for variable, value of updatedObject
       targetObject[variable.toLowerCase()] = value
     return


### PR DESCRIPTION
V8 wasn't optimizing the forIn loops in AgentModel.update. This replaces those forIns with regular for loops over Object.keys. The bodies of the loops have been moved to (inlineable) functions, which I think further allows optimization. Percent of total time for AgentModel.update decreased from 15% to 10% on climate change (with a bunch of CO2) on my machine, using latest Chrome Canary.

Note that I think this is a bad optimization in general. Object.keys is often slower than forIns. This is just a special case.

Also, Chrome still complains about forIns in AgentModel.update, but there aren't any left... not sure what that's about.

Note: A javascript forIn is equal to a coffeescript `for ... of ...` construct. Coffeescript's `for ... in ...` is compiled to a regular for loop.
