### PR TITLE
Close #179: fix link thickness rendering

### DIFF
--- a/app/assets/javascripts/TortoiseJS/agent/view.coffee
+++ b/app/assets/javascripts/TortoiseJS/agent/view.coffee
@@ -257,6 +257,28 @@ class TurtleView extends View
       x2 = end2.xcor
       y2 = end2.ycor
 
+      if link.thickness > @onePixel
+        shortestX = Math.min(x1 - x2, x2 - x1)
+        shortestY = Math.min(y1 - y2, y2 - y1)
+
+        theta = Math.atan2(shortestY, shortestX)
+        xd    = Math.abs(link.thickness * Math.cos(theta)) / 2
+        yd    = Math.abs(link.thickness * Math.sin(theta)) / 2
+
+        if 0 < link.heading < 180
+          x1 -= xd
+          x2 += xd
+        else
+          x1 += xd
+          x2 -= xd
+
+        if 90 < link.heading < 270
+          y1 += yd
+          y2 -= yd
+        else
+          y1 -= yd
+          y2 += yd
+
       wrapX = canWrapX and ((x1 - (x2 - @patchWidth) < Math.abs(x1 - x2)) or (x2 - (x1 - @patchWidth)) < Math.abs(x1 - x2))
       wrapY = canWrapY and ((y1 - (y2 - @patchHeight) < Math.abs(y1 - y2)) or (y2 - (y1 - @patchHeight) < Math.abs(y1 - y2)))
 

--- a/app/assets/javascripts/TortoiseJS/agent/view.coffee
+++ b/app/assets/javascripts/TortoiseJS/agent/view.coffee
@@ -257,6 +257,15 @@ class TurtleView extends View
       x2 = end2.xcor
       y2 = end2.ycor
 
+      distX = Math.abs(x1 - x2)
+      distY = Math.abs(y1 - y2)
+
+      worldWidth  = @maxpxcor - @minpxcor + 1
+      worldHeight = @maxpycor - @minpycor + 1
+
+      wrapX = canWrapX and (distX > worldWidth  / 2)
+      wrapY = canWrapY and (distY > worldHeight / 2)
+
       if link.thickness > @onePixel
         shortestX = Math.min(x1 - x2, x2 - x1)
         shortestY = Math.min(y1 - y2, y2 - y1)
@@ -278,9 +287,6 @@ class TurtleView extends View
         else
           y1 -= yd
           y2 += yd
-
-      wrapX = canWrapX and ((x1 - (x2 - @patchWidth) < Math.abs(x1 - x2)) or (x2 - (x1 - @patchWidth)) < Math.abs(x1 - x2))
-      wrapY = canWrapY and ((y1 - (y2 - @patchHeight) < Math.abs(y1 - y2)) or (y2 - (y1 - @patchHeight) < Math.abs(y1 - y2)))
 
       @ctx.strokeStyle = netlogoColorToCSS(link.color)
       @ctx.lineWidth = if link.thickness > @onePixel then link.thickness else @onePixel


### PR DESCRIPTION
Some caveats apply.

Covers most common cases where link extension occurs; doesn't cover cases such as, for instance, when the link wraps but the turtle at the end doesn't. Nor does it cover @qiemem 's weird case where the link wraps in all 3 directions but the turtle stays in the corner of the canvas.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/netlogo/galapagos/200)
<!-- Reviewable:end -->
