### PR TITLE
CompilerService loads models from filesystem instead of via HTTP

### DIFF
--- a/app/views/local/standaloneTortoise.scala.html
+++ b/app/views/local/standaloneTortoise.scala.html
@@ -18,12 +18,13 @@
     </style>
     <script type="text/javascript">
       @Html(js)
-      (function () {
+      var session =
+        (function () {
           var widgets = @Html(widgets);
           var code    = "@clean(nlogoCode)"
           var info    = "@clean(info)"
-          var session = Tortoise.fromCompiledModel('#model-container', widgets, code, info, '', true);
-      })()
+          return Tortoise.fromCompiledModel('#model-container', widgets, code, info, '', true);
+        })()
       @Html(libsJs)
       session.startLoop()
     </script>


### PR DESCRIPTION
I made this fix yesterday when attempting to use JMeter. JMeter tests run against the `/compile-url` path with the model url referring to something on the server resulted in JMeter crashing the server. This fixes that crash and should generally improve the load time of `/compile-url`.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/netlogo/galapagos/205)
<!-- Reviewable:end -->
