### PR TITLE
Add autoprefixer and fix IE

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@
 /.ensime_lucene/
 /.idea
 /logs/
+/node_modules/
 managed/
 project/project/
 target/

--- a/app/views/index.scala.html
+++ b/app/views/index.scala.html
@@ -1,9 +1,9 @@
 @views.html.mainTheme {
 
     <div class="alert-message block-message info" style="margin: 0 10%;">
-      <div style="display: flex; display: -webkit-box; justify-content: space-between; flex-wrap: wrap; align-items: flex-start;">
+      <div class="dynamic-column-holder">
 
-        <div style="flex: 3; -webkit-box-flex: 3; line-height: 18px; text-align: justify; font-size: 16px; padding-right: 3%;">
+        <div class="flex3" style="line-height: 18px; text-align: justify; font-size: 16px; padding-right: 3%;">
           We're bringing <a href="http://ccl.northwestern.edu/netlogo/">NetLogo</a> back to the browser!  With NetLogo Web
           (formerly known as "Tortoise"), we intend to provide a proper replacement for NetLogo applets, which went out of vogue a
           couple of years ago (thanks to various Java security problems).  Like with the applets of yore, NetLogo Web models
@@ -51,7 +51,7 @@
           not necessarily reflect the views of the National Science Foundation.</i>
         </div>
 
-        <div class="rounded" style="flex: 1; -webkit-box-flex: 1; font-size: 20px;">
+        <div class="rounded flex1" style="font-size: 20px;">
           <div class="spacious-entry" style="font-weight: bold; color: white; background-color: #343434; border: 3px solid #343434; border-bottom: 0; border-top-right-radius: 10px; border-top-left-radius: 10px;">Quick Links</div>
           <ul style="list-style-type: none; margin: -3px 0 0 0; padding-top: 8px; padding-bottom: 8px; color: #343434;
               border: 3px solid  #343434; border-bottom-right-radius: 10px; border-bottom-left-radius: 10px;">

--- a/app/views/tortoise.scala.html
+++ b/app/views/tortoise.scala.html
@@ -9,7 +9,7 @@
     <link rel="stylesheet" href='@routes.Assets.at("stylesheets/netlogo-syntax.css")' />
   </head>
   <body>
-    <div style="display: flex; justify-content: space-between; flex-wrap: wrap; margin-bottom: 20px; max-width: 900px; align-items: center;">
+    <div class="dynamic-row" style="margin-bottom: 20px; max-width: 900px;">
       <div style="width: 320px;">
         <h3>Find a Built-In Model</h3>
         <div class="model-list tortoise-model-list" style="width: 300px"></div>

--- a/build.sbt
+++ b/build.sbt
@@ -33,3 +33,5 @@ resolvers += bintray.Opts.resolver.repo("netlogo", "TortoiseAux")
 resolvers += bintray.Opts.resolver.repo("netlogo", "NetLogoHeadless")
 
 resolvers += Resolver.file("Local repo", file(System.getProperty("user.home") + "/.ivy2/local"))(Resolver.ivyStylePatterns)
+
+pipelineStages in Assets := Seq(autoprefixer)

--- a/package.json
+++ b/package.json
@@ -1,0 +1,5 @@
+{
+  "dependencies": {
+    "autoprefixer": "1.2.0"
+  }
+}

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -11,3 +11,6 @@ addSbtPlugin("com.typesafe.sbt" % "sbt-coffeescript" % "1.0.0")
 
 // get warnings when compiling build definition
 scalacOptions += "-feature"
+
+lazy val root = project.in(file(".")).dependsOn(sbtAutoprefixer)
+lazy val sbtAutoprefixer = uri("git://github.com/matthewrennie/sbt-autoprefixer")

--- a/public/stylesheets/classes.css
+++ b/public/stylesheets/classes.css
@@ -85,3 +85,35 @@ li.unknown {
 .spacious-entry {
   padding: 8px 8px;
 }
+
+
+
+/*
+
+ Flexbox stuff
+
+ Much of this could be inlined in styles, but we do this to allow the autoprefixer access to it --JAB 3/30/15
+
+ */
+
+.dynamic-row {
+  align-items: center;
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: space-between;
+}
+
+.dynamic-column-holder {
+  align-items: flex-start;
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: space-between;
+}
+
+.flex1 {
+  flex: 1;
+}
+
+.flex3 {
+  flex: 3;
+}

--- a/public/stylesheets/widgets.css
+++ b/public/stylesheets/widgets.css
@@ -1,22 +1,14 @@
-/* Just to be perfectly clear, all the -webkit- stuff for flexbox is all for
-   Safari. Once they get their act together, it should be removed.
-   BCH 11/14/2014 */
-
 .netlogo-model {
     border: 2px solid black;
     border-radius: 20px;
     display: flex;
-    display: -webkit-flex;
     padding: 20px;
     flex-flow: column;
-    -webkit-flex-flow: column;
 }
 
 .netlogo-header {
     display: flex;
-    display: -webkit-flex;
     flex-flow: row;
-    -webkit-flex-flow: row;
 }
 
 .netlogo-widget {
@@ -29,11 +21,6 @@
 }
 
 .netlogo-command,.netlogo-input {
-    -webkit-touch-callout: none;
-    -webkit-user-select: none;
-    -khtml-user-select: none;
-    -moz-user-select: none;
-    -ms-user-select: none;
     user-select: none;
 }
 
@@ -45,11 +32,8 @@
 .netlogo-tabs {
     margin-top: 20px;
     display: flex;
-    display: -webkit-flex;
     flex-flow: row;
-    -webkit-flex-flow: row;
     justify-content: space-around;
-    -webkit-justify-content: space-around;
 }
 
 .netlogo-tab {
@@ -71,25 +55,19 @@
 
 .netlogo-model-text {
     display: flex;
-    display: -webkit-flex;
     flex-flow: row;
-    -webkit-flex-flow: row;
     background-color: white;
 }
 
 .netlogo-code-container {
     flex: 1;
-    -webkit-flex: 1;
     display: flex;
-    display: -webkit-flex;
     flex-flow: column;
-    -webkit-flex-flow: column;
     background-color: white;
     margin: 10px;
 }
 .netlogo-code {
     flex: 1;
-    -webkit-flex: 1;
     font-family: monospace;
     overflow-x: scroll;
     border: inset;
@@ -100,32 +78,25 @@
 
 .netlogo-info {
     flex: 1;
-    -webkit-flex: 1;
     margin: 10px;
 }
 
 .netlogo-command-center {
   flex: 1;
-  -webkit-flex: 1;
   display: flex;
-  display: -webkit-flex;
   flex-direction: column;
-  -webkit-flex-direction: column;
   height: 175px;
   padding: 5px;
 }
 
 .netlogo-output-widget {
   display: flex;
-  display: -webkit-flex;
   padding: 5px;
 }
 
 .netlogo-output-area {
   flex-grow: 1;
-  -webkit-flex-grow: 1;
   flex-direction: column;
-  -webkit-flex-direction: column;
   background-color: white;
   margin: 0px;
   overflow: auto;
@@ -133,14 +104,11 @@
 
 .netlogo-command-center-input {
   display: flex;
-  display: -webkit-flex;
   flex-shrink: 0;
-  -webkit-flex-shrink: 0;
 }
 
 .netlogo-command-center-input input {
   flex-grow: 1;
-  -webkit-flex-grow: 1;
 }
 
 .netlogo-speed-slider {
@@ -148,30 +116,22 @@
     border: none;
     margin-right: 10px;
     flex: auto;
-    -webkit-flex: auto;
     display: flex;
-    display: -webkit-flex;
     align-items: center;
-    -webkit-align-items: center;
 }
 
 .netlogo-speed-slider input {
     border: none;
     flex: auto;
-    -webkit-flex: auto;
 }
 
 .netlogo-model input[type=range] {
     cursor: pointer;
-    cursor: -webkit-grab;
-    cursor: -moz-grab;
     cursor: grab;
 }
 
 .netlogo-model input[type=range]:active {
     cursor: pointer;
-    cursor: -webkit-grabbing;
-    cursor: -moz-grabbing;
     cursor: grabbing;
 }
 
@@ -185,16 +145,13 @@
 .netlogo-button {
     border: inherit;
     display: flex;
-    display: -webkit-flex;
-    justify-content: center;
-    -webkit-justify-content: center;
+    justify-content: space-around;
     align-items: center;
-    -webkit-align-items: center;
     padding: 0px;
 }
 
 .netlogo-button > span {
-    /* For some reason, Safari doesn't like -webkit-justify-content in buttons,
+    /* For some reason, Safari doesn't like justify-content in buttons,
        we have to resort to putting a span in the button that can then be
        centered.
        BCH 11/14/2014 */
@@ -220,9 +177,7 @@
 
 .netlogo-switcher {
     display: flex;
-    display: -webkit-flex;
     align-items: center;
-    -webkit-align-items: center;
 }
 
 .netlogo-slider {
@@ -268,11 +223,8 @@
 .netlogo-monitor {
     padding: 2px 4px;
     display: flex;
-    display: -webkit-flex;
     flex-flow: column;
-    -webkit-flex-flow: column;
     justify-content: space-around;
-    -webkit-justify-content: space-around;
 }
 
 .netlogo-monitor > .netlogo-value {
@@ -287,21 +239,15 @@
 .netlogo-input-box {
     padding: 2px 4px;
     display: flex;
-    display: -webkit-flex;
     flex-flow: column;
-    -webkit-flex-flow: column;
     justify-content: space-around;
-    -webkit-justify-content: space-around;
 }
 
 .netlogo-chooser {
     padding: 2px 4px;
     display: flex;
-    display: -webkit-flex;
     flex-flow: column;
-    -webkit-flex-flow: column;
     justify-content: space-around;
-    -webkit-justify-content: space-around;
 }
 
 .netlogo-plot {

--- a/public/stylesheets/widgets.css
+++ b/public/stylesheets/widgets.css
@@ -9,6 +9,7 @@
 .netlogo-header {
     display: flex;
     flex-flow: row;
+    align-items: baseline;
 }
 
 .netlogo-widget {
@@ -117,7 +118,11 @@
     margin-right: 10px;
     flex: auto;
     display: flex;
-    align-items: center;
+    align-items: baseline;
+}
+
+.netlogo-widget input[type=range]::-ms-tooltip {
+  display: none;
 }
 
 .netlogo-speed-slider input {

--- a/public/stylesheets/widgets.css
+++ b/public/stylesheets/widgets.css
@@ -68,7 +68,7 @@
     margin: 10px;
 }
 .netlogo-code {
-    flex: 1;
+    flex: 1 1 auto;
     font-family: monospace;
     overflow-x: scroll;
     border: inset;


### PR DESCRIPTION
#212 is still an issue in IE10, but is fixed here in IE11.

Also monitors' output boxes don't stretch out in IE10, but are otherwise aligned correctly.

@TheBizzle Take a look and let me know how you'd like it squashed.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/netlogo/galapagos/224)
<!-- Reviewable:end -->
