### PR TITLE
eliminate annoying warning in sbt build about an slf4j conflict

### DIFF
--- a/project/bintray.sbt
+++ b/project/bintray.sbt
@@ -3,4 +3,10 @@ resolvers += Resolver.url(
    url("http://dl.bintray.com/content/sbt/sbt-plugin-releases"))(
        Resolver.ivyStylePatterns)
 
-addSbtPlugin("me.lessis" % "bintray-sbt" % "0.1.2")
+// excluding the sl4fj-nop dependency prevents a warning about
+// having two different slf4j implementations on the classpath,
+// since sbt-js-engine depends on slf4j-simple - ST 6/3/15
+addSbtPlugin(
+  "me.lessis" % "bintray-sbt" % "0.1.2"
+    exclude ("org.slf4j", "slf4j-nop")
+)


### PR DESCRIPTION
the warning in question:

```
SLF4J: Class path contains multiple SLF4J bindings.
SLF4J: Found binding in [jar:file:/Users/seth_tisue/.ivy2/cache/org.slf4j/slf4j-nop/jars/slf4j-nop-1.7.7.jar!/org/slf4j/impl/StaticLoggerBinder.class]
SLF4J: Found binding in [jar:file:/Users/seth_tisue/.ivy2/cache/org.slf4j/slf4j-simple/jars/slf4j-simple-1.7.7.jar!/org/slf4j/impl/StaticLoggerBinder.class]
SLF4J: See http://www.slf4j.org/codes.html#multiple_bindings for an explanation.
SLF4J: Actual binding is of type [org.slf4j.helpers.NOPLoggerFactory]
```