### PR TITLE
Deduplicate test assets

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,3 +1,5 @@
+import com.typesafe.sbt.web.Import.WebKeys.webJarsDirectory
+
 name := "Galapagos"
 
 version := "1.0-SNAPSHOT"
@@ -40,4 +42,14 @@ resolvers += bintray.Opts.resolver.repo("netlogo", "NetLogoHeadless")
 
 resolvers += Resolver.file("Local repo", file(System.getProperty("user.home") + "/.ivy2/local"))(Resolver.ivyStylePatterns)
 
-pipelineStages in Assets := Seq(autoprefixer)
+pipelineStages in Assets += autoprefixer
+
+includeFilter in autoprefixer := Def.setting {
+  val webJarDir     = (webJarsDirectory in Assets).value.getPath
+  val testWebJarDir = (webJarsDirectory in TestAssets).value.getPath
+  new FileFilter {
+    override def accept(file: java.io.File) = {
+      file.getName.endsWith(".css") && ! (file.getPath.contains(webJarDir) || file.getPath.contains(testWebJarDir))
+    }
+  }
+}.value


### PR DESCRIPTION
This gets tests running again. I haven't tracked down the exact cause of the bug, but I'm pretty sure it has to do with autoprefixer trying to autoprefix css files pulled out of webjars. This should fix it, as long as our tests don't depend on assets.