### PR TITLE
upgrade to Scala 2.11.7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,6 @@ sudo: false
 jdk: oraclejdk8
 language: scala
 scala:
-  - 2.11.6
+  - 2.11.7
 script:
   - "sbt test"

--- a/build.sbt
+++ b/build.sbt
@@ -4,7 +4,7 @@ name := "Galapagos"
 
 version := "1.0-SNAPSHOT"
 
-scalaVersion := "2.11.6"
+scalaVersion := "2.11.7"
 
 scalacOptions ++= Seq(
   "-encoding", "UTF-8",

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -5,7 +5,7 @@ logLevel := Level.Warn
 resolvers += "Typesafe repository" at "http://repo.typesafe.com/typesafe/releases/"
 
 // Use the Play sbt plugin for Play projects
-addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.4.0")
+addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.4.1")
 
 addSbtPlugin("com.typesafe.sbt" % "sbt-coffeescript" % "1.0.0")
 


### PR DESCRIPTION
Scala 2.11.7 has been published to Maven Central, but hasn't yet
been announced. it's still possible some last-minute regression
will be discovered, so even if this passes Travis, you might
wait to merge this until the release has actually been announced