### PR TITLE
Give slider number precedence over labels.

### DIFF
--- a/app/assets/javascripts/TortoiseJS/agent/widgets.coffee
+++ b/app/assets/javascripts/TortoiseJS/agent/widgets.coffee
@@ -285,12 +285,15 @@ partials =
     <label class="netlogo-widget netlogo-slider netlogo-input" style="{{>dimensions}}">
       <input type="range"
              max="{{maxValue}}" min="{{minValue}}" step="{{step}}" value="{{currentValue}}" />
-      <span class="netlogo-label">{{display}}</span>
-      <span class="netlogo-value">
-        <input type="number"
-               min={{minValue}} max={{maxValue}} value={{currentValue}} step={{step}} />
-        {{#units}}{{units}}{{/}}
-      </span>
+      <div class="netlogo-slider-label">
+        <span class="netlogo-label">{{display}}</span>
+        <span class="netlogo-slider-value">
+          <input type="number"
+                 style="width: {{currentValue.toString().length + 2}}ch"
+                 min={{minValue}} max={{maxValue}} value={{currentValue}} step={{step}} />
+          {{#units}}{{units}}{{/}}
+        </span>
+      </div>
     </label>
     """
   button:

--- a/app/assets/javascripts/TortoiseJS/control/session-lite.coffee
+++ b/app/assets/javascripts/TortoiseJS/control/session-lite.coffee
@@ -64,7 +64,7 @@ class window.SessionLite
   recompile: ->
     # This is a temporary workaround for the fact that models can't be reloaded
     # without clearing the world. BCH 1/9/2015
-    world.clearAll();
+    world.clearAll()
     @widgetController.redraw()
     compile('code', @widgetController.code(), [], [], @widgetController.widgets, (res) ->
       if res.model.success

--- a/public/stylesheets/widgets.css
+++ b/public/stylesheets/widgets.css
@@ -207,7 +207,7 @@
     cursor: default;
 }
 
-.netlogo-slider > input[type=range] {
+.netlogo-slider input[type=range] {
     padding: 0px;
     width: 100%;
     margin: 0px;
@@ -217,26 +217,29 @@
     background-color: transparent;
 }
 
-.netlogo-slider > .netlogo-label {
-    float: left;
+.netlogo-slider-label {
+    display: flex;
+    justify-content: space-between;
 }
 
-.netlogo-slider > .netlogo-value {
-    margin: 0px;
-    border: 1px;
-    padding: 0px;
-    text-align: right;
-    display: block;
+.netlogo-slider-label .netlogo-label {
+    text-overflow: ellipsis;
     overflow: hidden;
+    white-space: nowrap;
+    min-width: 0;
+    flex: 1 1 auto;
 }
 
-.netlogo-slider > .netlogo-value > input[type=number] {
+.netlogo-slider-label .netlogo-slider-value {
+    flex: 0 0 auto;
+}
+
+.netlogo-slider-label input[type=number] {
     margin: 0px;
     border: 1px;
     padding: 0px;
-    text-align: right;
-    width: 45px;
 }
+
 
 .netlogo-monitor {
     padding: 2px 4px;


### PR DESCRIPTION
Fixes #198 

The tricky part was making the number inputs to grow while staying rigidly connected to the righthand side.

Tested on Chrome, FF, Safari, and IE11. IE11 can get a little funny when the numbers get really big (a dozen digits or so), but well within acceptable behavior. 

WSP is a good test as it's pretty dense compared to other models in the library:

![image](https://cloud.githubusercontent.com/assets/28215/8460866/c38c332e-1fed-11e5-896b-3ca565489ca3.png)


![image](https://cloud.githubusercontent.com/assets/28215/8460846/98204c8e-1fed-11e5-9a51-7549a2943b14.png)
