### PR TITLE
Recompiling a model throws away its custom shape information

### DIFF
--- a/app/assets/javascripts/TortoiseJS/control/session-lite.coffee
+++ b/app/assets/javascripts/TortoiseJS/control/session-lite.coffee
@@ -150,7 +150,9 @@ window.compile = (source, model, commands, reporters, widgets,
     model: model,
     widgets: JSON.stringify(widgets),
     commands: JSON.stringify(commands),
-    reporters: JSON.stringify(reporters)
+    reporters: JSON.stringify(reporters),
+    turtleShapes: JSON.stringify(turtleShapes ? []),
+    linkShapes: JSON.stringify(linkShapes ? [])
   }
   compileCallback = (res) ->
     onFulfilled(JSON.parse(res))

--- a/build.sbt
+++ b/build.sbt
@@ -20,7 +20,7 @@ scalacOptions ++= Seq(
 lazy val root = (project in file(".")).enablePlugins(PlayScala)
 
 libraryDependencies ++= Seq(
-  "org.nlogo" % "tortoise" % "0.1-e630a86",
+  "org.nlogo" % "tortoise" % "0.1-fc2f905",
   cache,
   "com.typesafe.akka" %% "akka-testkit" % "2.3.11" % "test",
   "org.scalatestplus" %% "play" % "1.4.0-M3" % "test"

--- a/test/CompilerServiceIntegrationTest.scala
+++ b/test/CompilerServiceIntegrationTest.scala
@@ -1,0 +1,74 @@
+import
+  org.scalatestplus.play.{PlaySpec, OneAppPerSuite}
+
+import
+  play.api.{libs, mvc, test},
+    libs.{ iteratee, json },
+      iteratee.Iteratee,
+      json.{ JsObject, Json, JsString },
+    mvc.{ EssentialAction, Result },
+    test.{ FakeRequest, FakeApplication, Helpers },
+      Helpers.{ await, call, defaultAwaitTimeout, writeableOf_AnyContentAsFormUrlEncoded }
+
+import
+  scala.concurrent.Future
+
+class CompilerServiceIntegrationTest extends PlaySpec with OneAppPerSuite {
+
+  import CompilerServiceHelpers._
+  import scala.concurrent.ExecutionContext.Implicits.global
+
+  override implicit lazy val app: FakeApplication =
+    FakeApplication(additionalConfiguration = Map("akka.log-dead-letters" -> 0))
+
+  "CompilerService controller" must {
+    Map(
+      "wolf sheep"          -> wolfSheep,
+      "custom turtle shape" -> breedProcedures,
+      "custom link shape"   -> linkBreeds
+    ).foreach {
+      case (name, modelText) =>
+
+        s"preserve $name model information" in {
+          val (firstResult, firstResultBody) = await(makeRequest("POST", "/compile-nlogo", "model" -> modelText))
+          firstResult.header.status mustEqual 200
+
+          val fields = sanitizedJsonModel(firstResultBody, "turtleShapes", "linkShapes")
+
+          val renamedFields = fields + ("model" -> fields("code"))
+
+          val (secondResult, secondResultBody) = await(makeRequest("POST", "/compile-code", renamedFields.toSeq: _*))
+          secondResult.header.status mustEqual 200
+          secondResultBody mustEqual firstResultBody
+        }
+    }
+  }
+
+  private def makeRequest(method: String, path: String, formBody: (String, String)*): Future[(Result, String)] = {
+    val req = FakeRequest(method, path).withFormUrlEncodedBody(formBody: _*)
+    val (_, handler) = app.requestHandler.handlerForRequest(req)
+    call(handler.asInstanceOf[EssentialAction], req).flatMap[(Result, String)] { res =>
+      res.body |>>> Iteratee.consume[Array[Byte]]().map(new String(_, "UTF-8")).map((res, _))
+    }
+  }
+
+  private def sanitizedJsonModel(rawJson: String, modelVars: String*): Map[String, String] = {
+    val jobject@JsObject(jsonFields) = Json.parse(rawJson)
+
+    val JsString(modelJs) = (jobject \ "model" \ "result").get
+
+    val fields = jsonFields.toMap.map {
+      case ("widgets", JsString(s)) => ("widgets", Json.prettyPrint(Json.parse(s.replaceAll(":function\\(\\) \\{.*\\},\"", ":null,\""))))
+      case (k,         JsString(s)) => (k,         s)
+      case (k,         j)           => (k,         Json.prettyPrint(j))
+    }
+
+    val jsVarRegex = """(?m)^var (\w+) = (.*);$""".r
+
+    val declaredVars = jsVarRegex.findAllMatchIn(modelJs).map {
+      case jsVarRegex(varName, varValue) => varName -> varValue
+    }
+
+    fields ++ declaredVars.filter(t => modelVars.contains(t._1))
+  }
+}


### PR DESCRIPTION
Originally NetLogo/Tortoise#145, reported by @ToonTalk.

See [this model](http://li425-91.members.linode.com:9000/tortoise#https://gist.githubusercontent.com/TheBizzle/8a04dd988d7c5986402f/raw/2dbf8b1987f958db5ea62c38e197f0ca588922e5/Garbage.nlogo) for a simpler demonstration of the problem.

My model provides a custom turtle shape called "thing".  If you press "setup" right after loading the page, the "thing" shape appears correctly.  If you open the "Code" tab and press "compile", though, "setup" starts to show you the turtles with the default turtle shape.  Once this is done, there is no going back, unless you reload the page.

I've dug around in the code a bit, and it looks to me like shape information simply isn't being persisted for some reason.  We don't notice this on models like Wolf Sheep Predation, because their shapes are all defaults shapes.

The "thing" shape is not included at all in the array of serialized shapes passed into the workspace constructor in the compilation response.  This suggests to me that Beak or maybe the Galapagos server itself is doing something wrong.