### PR TITLE
Add export HTML to /tortoise page

### DIFF
--- a/app/Filters.scala
+++ b/app/Filters.scala
@@ -1,0 +1,15 @@
+// (C) Uri Wilensky. https://github.com/NetLogo/Galapagos
+
+import
+  javax.inject.Inject
+
+import
+  play.{ api, filters },
+    api.{ http, mvc },
+      http.HttpFilters,
+      mvc.EssentialFilter,
+    filters.cors.CORSFilter
+
+class Filters @Inject() (corsFilter: CORSFilter) extends HttpFilters {
+  override def filters: Seq[EssentialFilter] = Seq(corsFilter)
+}

--- a/app/assets/javascripts/TortoiseJS/agent/widgets.coffee
+++ b/app/assets/javascripts/TortoiseJS/agent/widgets.coffee
@@ -238,7 +238,11 @@ template =
 
       <div class="netlogo-subheader">
         {{# !readOnly }}
-        <button class="netlogo-export-button" style="margin-bottom: 10px;" id="export-button" on-click="exportnlogo">Export to NetLogo...</button>
+        <div>
+          Export:
+          <button class="netlogo-export-button" style="margin-bottom: 10px;" on-click="exportnlogo">NetLogo</button>
+          <button class="netlogo-export-button" style="margin-bottom: 10px;" on-click="exportHtml">HTML</button>
+        </div>
         {{/}}
         <div class="netlogo-powered-by">
           <a href="http://ccl.northwestern.edu/netlogo/">

--- a/app/assets/javascripts/TortoiseJS/control/session-lite.coffee
+++ b/app/assets/javascripts/TortoiseJS/control/session-lite.coffee
@@ -66,15 +66,16 @@ class window.SessionLite
   recompile: ->
     # This is a temporary workaround for the fact that models can't be reloaded
     # without clearing the world. BCH 1/9/2015
-    Tortoise.startLoading()
-    world.clearAll()
-    @widgetController.redraw()
-    codeCompile(@widgetController.code(), [], [], @widgetController.widgets, (res) ->
-      if res.model.success
-        globalEval(res.model.result)
-      else
-        alert(res.model.result.map((err) -> err.message).join('\n'))
-      Tortoise.finishLoading()
+    Tortoise.startLoading( =>
+      world.clearAll()
+      @widgetController.redraw()
+      codeCompile(@widgetController.code(), [], [], @widgetController.widgets, (res) ->
+        if res.model.success
+          globalEval(res.model.result)
+        else
+          alert(res.model.result.map((err) -> err.message).join('\n'))
+        Tortoise.finishLoading()
+      )
     )
 
 
@@ -122,11 +123,15 @@ class window.SessionLite
 
 window.Tortoise = {
 
-  startLoading: ->
-    $("#loading-overlay").show()
+  # process: optional argument that allows the loading process to be async to
+  # give the animation time to come up.
+  startLoading: (process) ->
+    document.querySelector("#loading-overlay").style.display = ""
+    # This gives the loading animation time to come up. BCH 7/25/2015
+    if (process?) then setTimeout(process, 20)
 
   finishLoading: ->
-    $("#loading-overlay").hide()
+    document.querySelector("#loading-overlay").style.display = "none"
 
   # We separate on both / and \ because we get URLs and Windows-esque filepaths
   normalizedFileName: (path) ->

--- a/app/assets/javascripts/TortoiseJS/control/session-lite.coffee
+++ b/app/assets/javascripts/TortoiseJS/control/session-lite.coffee
@@ -102,24 +102,27 @@ class window.SessionLite
     suggestion = @widgetController.ractive.get('filename').replace(/\.nlogo$/, ".html")
     filename = window.prompt('Filename:', suggestion)
     if filename?
-      jsRoutes.controllers.Local.standalone().ajax({
-        success: (response) =>
-          nlogo = @getNlogo()
-          if nlogo.success
-            parser = new DOMParser()
-            dom = parser.parseFromString(response, "text/html")
-            nlogoScript = dom.querySelector("#nlogo-code")
-            nlogoScript.textContent = nlogo.result
-            nlogoScript.dataset.filename = filename.replace(/\.html$/, ".nlogo")
-            wrapper = document.createElement("div")
-            wrapper.appendChild(dom.documentElement)
-            exportBlob = new Blob([wrapper.innerHTML], {type: "text/html:charset=utf-8"})
-            saveAs(exportBlob, filename)
+      window.req = new XMLHttpRequest()
+      req.open('GET', standaloneURL)
+      req.onreadystatechange = =>
+        if req.readyState == req.DONE
+          if req.status is 200
+            nlogo = @getNlogo()
+            if nlogo.success
+              parser = new DOMParser()
+              dom = parser.parseFromString(req.responseText, "text/html")
+              nlogoScript = dom.querySelector("#nlogo-code")
+              nlogoScript.textContent = nlogo.result
+              nlogoScript.dataset.filename = filename.replace(/\.html$/, ".nlogo")
+              wrapper = document.createElement("div")
+              wrapper.appendChild(dom.documentElement)
+              exportBlob = new Blob([wrapper.innerHTML], {type: "text/html:charset=utf-8"})
+              saveAs(exportBlob, filename)
+            else
+              alert(nlogo.result.map((err) -> err.message).join("\n"))
           else
-            alert(nlogo.result.map((err) -> err.message).join("\n"))
-        error: (response) ->
-          alert("Couldn't get standalone HTML: #{response}")
-      })
+            alert("Couldn't get standalone page")
+      req.send("")
 
   makeForm:(method, path, data) ->
     form = document.createElement('form')

--- a/app/controllers/Local.scala
+++ b/app/controllers/Local.scala
@@ -31,6 +31,16 @@ class Local @Inject() (application: PlayApplication) extends Controller {
       Ok(views.html.tortoise(mode))
   }
 
+  def standalone: Action[AnyContent] = Action {
+    implicit request =>
+      Ok(views.html.simulation(TemplateUtil.inlineScript, TemplateUtil.inlineStyle))
+  }
+
+  def web: Action[AnyContent] = Action {
+    implicit request =>
+      Ok(views.html.simulation(TemplateUtil.outsourceScript, TemplateUtil.outsourceStyle))
+  }
+
   def engine: Action[AnyContent] = Action {
     implicit request => OkJS(engineStr)
   }

--- a/app/controllers/TemplateUtil.scala
+++ b/app/controllers/TemplateUtil.scala
@@ -1,0 +1,27 @@
+// (C) Uri Wilensky. https://github.com/NetLogo/Galapagos
+
+package controllers
+
+import models.Util.usingSource
+
+import
+  play.api.Play,
+    Play.current
+
+import play.twirl.api.Html
+
+object TemplateUtil {
+  private def inlineTag(tag: String, props: String)(url: String): Html = {
+    val source = usingSource(_.fromURL(url))(_.mkString)
+    Html(s"<$tag $props>$source</$tag>")
+  }
+
+  private def outsourceTag(tag: String, props: String, urlProp: String)(url: String): Html = {
+    Html(s"""<$tag $props $urlProp="$url"></$tag>""")
+  }
+
+  def inlineScript:    (String) => Html = inlineTag("script", "") _
+  def outsourceScript: (String) => Html = outsourceTag("script", "", "src") _
+  def inlineStyle:     (String) => Html = inlineTag("style", "") _
+  def outsourceStyle:  (String) => Html = outsourceTag("link", "rel=\"stylesheet\"", "href") _
+}

--- a/app/views/simulation.scala.html
+++ b/app/views/simulation.scala.html
@@ -10,9 +10,11 @@
     @style(route("stylesheets/widgets.css"))
     @style(route("stylesheets/classic.css"))
     @style(route("stylesheets/netlogo-syntax.css"))
+    @style(route("stylesheets/spinner.css"))
   </head>
-  <body>
-    <div id="model-container"></div>
+  <body style="margin: 0px;">
+    @views.html.spinner()
+    <div id="model-container" style="display: inline-block;"></div>
   </body>
   @script(route("lib/filesaver.js/FileSaver.js"))
   @script(route("lib/markdown-js/markdown.js"))
@@ -41,13 +43,39 @@
 
   <script>
     var modelContainer = document.querySelector("#model-container");
-    if (window.location.hash) {
-      var url = window.location.hash.substring(1);
-      var session;
+    var index = window.location.href.indexOf("?");
+    var session;
+    if (index > -1) {
+      var url = window.location.href.substring(index+1);
+      console.log(url);
       Tortoise.fromURL(url, modelContainer, function (res) {
         session = res;
         session.startLoop();
       });
+    }
+
+    window.addEventListener("message", function (e) {
+      if (session) {
+        session.teardown();
+      }
+      Tortoise.fromNlogo(e.data.nlogo, modelContainer, e.data.path, function (res) {
+        session = res;
+        session.startLoop();
+      });
+    });
+
+    if (parent !== window) {
+      var width = "", height = "";
+      window.setInterval(function() {
+        if (modelContainer.scrollWidth !== width || modelContainer.scrollHeight !== height) {
+          width = modelContainer.scrollWidth;
+          height = modelContainer.scrollHeight;
+          parent.postMessage({
+            width: modelContainer.scrollWidth,
+            height: modelContainer.scrollHeight
+          }, "*");
+        }
+      }, 200);
     }
   </script>
 </html>

--- a/app/views/simulation.scala.html
+++ b/app/views/simulation.scala.html
@@ -1,0 +1,53 @@
+@(script: String => Html, style: String => Html)(implicit request: Request[_])
+
+@route(path: String) = @{
+  routes.Assets.at(path).absoluteURL
+}
+
+<html>
+  <head>
+    @style(route("lib/codemirror/lib/codemirror.css"))
+    @style(route("stylesheets/widgets.css"))
+    @style(route("stylesheets/classic.css"))
+    @style(route("stylesheets/netlogo-syntax.css"))
+  </head>
+  <body>
+    <div id="model-container"></div>
+  </body>
+  @script(route("lib/filesaver.js/FileSaver.js"))
+  @script(route("lib/markdown-js/markdown.js"))
+  @script(route("lib/highcharts/adapters/standalone-framework.js"))
+  @script(route("lib/highcharts/highcharts.js"))
+  @script(route("lib/highcharts/modules/exporting.js"))
+  @script(route("lib/ractive/ractive.js"))
+  @script(route("lib/codemirror/lib/codemirror.js"))
+  @script(route("lib/codemirror/addon/mode/simple.js"))
+
+  @script(routes.CompilerService.netLogoWeb.absoluteURL)
+  @script(routes.Local.engine.absoluteURL)
+
+  @script(route("javascripts/TortoiseJS/agent/colors.js"))
+  @script(route("javascripts/TortoiseJS/agent/drawshape.js"))
+  @script(route("javascripts/TortoiseJS/agent/defaultshapes.js"))
+  @script(route("javascripts/TortoiseJS/agent/linkdrawer.js"))
+  @script(route("javascripts/TortoiseJS/agent/view.js"))
+  @script(route("javascripts/TortoiseJS/agent/editor.js"))
+  @script(route("javascripts/TortoiseJS/agent/info.js"))
+  @script(route("javascripts/TortoiseJS/agent/output.js"))
+  @script(route("javascripts/TortoiseJS/agent/console.js"))
+  @script(route("javascripts/TortoiseJS/agent/widgets.js"))
+  @script(route("javascripts/TortoiseJS/control/session-lite.js"))
+  @script(route("javascripts/plot/highchartsops.js"))
+
+  <script>
+    var modelContainer = document.querySelector("#model-container");
+    if (window.location.hash) {
+      var url = window.location.hash.substring(1);
+      var session;
+      Tortoise.fromURL(url, modelContainer, function (res) {
+        session = res;
+        session.startLoop();
+      });
+    }
+  </script>
+</html>

--- a/app/views/simulation.scala.html
+++ b/app/views/simulation.scala.html
@@ -15,82 +15,82 @@
   <body style="margin: 0px;">
     @views.html.spinner()
     <div id="model-container" style="display: inline-block;"></div>
-  </body>
-  @script(route("lib/jquery/jquery.js"))
-  @script(route("lib/filesaver.js/FileSaver.js"))
-  @script(route("lib/markdown-js/markdown.js"))
-  @script(route("lib/highcharts/adapters/standalone-framework.js"))
-  @script(route("lib/highcharts/highcharts.js"))
-  @script(route("lib/highcharts/modules/exporting.js"))
-  @script(route("lib/ractive/ractive.js"))
-  @script(route("lib/codemirror/lib/codemirror.js"))
-  @script(route("lib/codemirror/addon/mode/simple.js"))
+    @script(route("lib/jquery/jquery.js"))
+    @script(route("lib/filesaver.js/FileSaver.js"))
+    @script(route("lib/markdown-js/markdown.js"))
+    @script(route("lib/highcharts/adapters/standalone-framework.js"))
+    @script(route("lib/highcharts/highcharts.js"))
+    @script(route("lib/highcharts/modules/exporting.js"))
+    @script(route("lib/ractive/ractive.js"))
+    @script(route("lib/codemirror/lib/codemirror.js"))
+    @script(route("lib/codemirror/addon/mode/simple.js"))
 
-  @script(routes.CompilerService.netLogoWeb.absoluteURL)
-  @script(routes.Local.engine.absoluteURL)
+    @script(routes.CompilerService.netLogoWeb.absoluteURL)
+    @script(routes.Local.engine.absoluteURL)
 
-  @script(route("javascripts/TortoiseJS/agent/colors.js"))
-  @script(route("javascripts/TortoiseJS/agent/drawshape.js"))
-  @script(route("javascripts/TortoiseJS/agent/defaultshapes.js"))
-  @script(route("javascripts/TortoiseJS/agent/linkdrawer.js"))
-  @script(route("javascripts/TortoiseJS/agent/view.js"))
-  @script(route("javascripts/TortoiseJS/agent/editor.js"))
-  @script(route("javascripts/TortoiseJS/agent/info.js"))
-  @script(route("javascripts/TortoiseJS/agent/output.js"))
-  @script(route("javascripts/TortoiseJS/agent/console.js"))
-  @script(route("javascripts/TortoiseJS/agent/widgets.js"))
-  @script(route("javascripts/TortoiseJS/control/session-lite.js"))
-  @script(route("javascripts/plot/highchartsops.js"))
+    @script(route("javascripts/TortoiseJS/agent/colors.js"))
+    @script(route("javascripts/TortoiseJS/agent/drawshape.js"))
+    @script(route("javascripts/TortoiseJS/agent/defaultshapes.js"))
+    @script(route("javascripts/TortoiseJS/agent/linkdrawer.js"))
+    @script(route("javascripts/TortoiseJS/agent/view.js"))
+    @script(route("javascripts/TortoiseJS/agent/editor.js"))
+    @script(route("javascripts/TortoiseJS/agent/info.js"))
+    @script(route("javascripts/TortoiseJS/agent/output.js"))
+    @script(route("javascripts/TortoiseJS/agent/console.js"))
+    @script(route("javascripts/TortoiseJS/agent/widgets.js"))
+    @script(route("javascripts/TortoiseJS/control/session-lite.js"))
+    @script(route("javascripts/plot/highchartsops.js"))
 
-  @helper.javascriptRouter("jsRoutes")(
-    routes.javascript.Local.standalone
-  )
+    @helper.javascriptRouter("jsRoutes")(
+      routes.javascript.Local.standalone
+    )
 
-  <!-- This can be used to insert nlogo code into this page -->
-  <script type="text/nlogo" id="nlogo-code" date-filename="model.nlogo"></script>
+    <!-- This can be used to insert nlogo code into this page -->
+    <script type="text/nlogo" id="nlogo-code" date-filename="model.nlogo"></script>
 
-  <script>
-    var modelContainer = document.querySelector("#model-container");
-    var index          = window.location.href.indexOf("?");
-    var nlogoScript    = document.querySelector("#nlogo-code");
-    var session;
+    <script>
+      var modelContainer = document.querySelector("#model-container");
+      var index          = window.location.href.indexOf("?");
+      var nlogoScript    = document.querySelector("#nlogo-code");
+      var session;
 
-    if (nlogoScript.textContent.length > 0) {
-      Tortoise.fromNlogo(nlogoScript.textContent, modelContainer, nlogoScript.dataset.filename, function (res) {
-        session = res;
-        session.startLoop();
-      });
-    } else if (index > -1) {
-      var url = window.location.href.substring(index+1);
-      console.log(url);
-      Tortoise.fromURL(url, modelContainer, function (res) {
-        session = res;
-        session.startLoop();
-      });
-    }
-
-    window.addEventListener("message", function (e) {
-      if (session) {
-        session.teardown();
+      if (nlogoScript.textContent.length > 0) {
+        Tortoise.fromNlogo(nlogoScript.textContent, modelContainer, nlogoScript.dataset.filename, function (res) {
+          session = res;
+          session.startLoop();
+        });
+      } else if (index > -1) {
+        var url = window.location.href.substring(index+1);
+        console.log(url);
+        Tortoise.fromURL(url, modelContainer, function (res) {
+          session = res;
+          session.startLoop();
+        });
       }
-      Tortoise.fromNlogo(e.data.nlogo, modelContainer, e.data.path, function (res) {
-        session = res;
-        session.startLoop();
-      });
-    });
 
-    if (parent !== window) {
-      var width = "", height = "";
-      window.setInterval(function() {
-        if (modelContainer.scrollWidth !== width || modelContainer.scrollHeight !== height) {
-          width = modelContainer.scrollWidth;
-          height = modelContainer.scrollHeight;
-          parent.postMessage({
-            width: modelContainer.scrollWidth,
-            height: modelContainer.scrollHeight
-          }, "*");
+      window.addEventListener("message", function (e) {
+        if (session) {
+          session.teardown();
         }
-      }, 200);
-    }
-  </script>
+        Tortoise.fromNlogo(e.data.nlogo, modelContainer, e.data.path, function (res) {
+          session = res;
+          session.startLoop();
+        });
+      });
+
+      if (parent !== window) {
+        var width = "", height = "";
+        window.setInterval(function() {
+          if (modelContainer.scrollWidth !== width || modelContainer.scrollHeight !== height) {
+            width = modelContainer.scrollWidth;
+            height = modelContainer.scrollHeight;
+            parent.postMessage({
+              width: modelContainer.scrollWidth,
+              height: modelContainer.scrollHeight
+            }, "*");
+          }
+        }, 200);
+      }
+    </script>
+  </body>
 </html>

--- a/app/views/simulation.scala.html
+++ b/app/views/simulation.scala.html
@@ -15,7 +15,6 @@
   <body style="margin: 0px;">
     @views.html.spinner()
     <div id="model-container" style="display: inline-block;"></div>
-    @script(route("lib/jquery/jquery.js"))
     @script(route("lib/filesaver.js/FileSaver.js"))
     @script(route("lib/markdown-js/markdown.js"))
     @script(route("lib/highcharts/adapters/standalone-framework.js"))
@@ -52,6 +51,7 @@
       var modelContainer = document.querySelector("#model-container");
       var index          = window.location.href.indexOf("?");
       var nlogoScript    = document.querySelector("#nlogo-code");
+      var standaloneURL  = "@routes.Local.standalone.absoluteURL";
       var session;
 
       if (nlogoScript.textContent.length > 0) {

--- a/app/views/simulation.scala.html
+++ b/app/views/simulation.scala.html
@@ -16,6 +16,7 @@
     @views.html.spinner()
     <div id="model-container" style="display: inline-block;"></div>
   </body>
+  @script(route("lib/jquery/jquery.js"))
   @script(route("lib/filesaver.js/FileSaver.js"))
   @script(route("lib/markdown-js/markdown.js"))
   @script(route("lib/highcharts/adapters/standalone-framework.js"))
@@ -41,11 +42,25 @@
   @script(route("javascripts/TortoiseJS/control/session-lite.js"))
   @script(route("javascripts/plot/highchartsops.js"))
 
+  @helper.javascriptRouter("jsRoutes")(
+    routes.javascript.Local.standalone
+  )
+
+  <!-- This can be used to insert nlogo code into this page -->
+  <script type="text/nlogo" id="nlogo-code" date-filename="model.nlogo"></script>
+
   <script>
     var modelContainer = document.querySelector("#model-container");
-    var index = window.location.href.indexOf("?");
+    var index          = window.location.href.indexOf("?");
+    var nlogoScript    = document.querySelector("#nlogo-code");
     var session;
-    if (index > -1) {
+
+    if (nlogoScript.textContent.length > 0) {
+      Tortoise.fromNlogo(nlogoScript.textContent, modelContainer, nlogoScript.dataset.filename, function (res) {
+        session = res;
+        session.startLoop();
+      });
+    } else if (index > -1) {
       var url = window.location.href.substring(index+1);
       console.log(url);
       Tortoise.fromURL(url, modelContainer, function (res) {

--- a/app/views/tortoise.scala.html
+++ b/app/views/tortoise.scala.html
@@ -1,18 +1,13 @@
-@(currentMode: String)
+@(currentMode: String)(implicit request: Request[_])
 
 <html>
   <head>
     <title>NetLogo Web</title>
     <link rel="stylesheet" href='@routes.Assets.at("lib/chosen/chosen.css")' />
-    <link rel="stylesheet" href='@routes.Assets.at("lib/codemirror/lib/codemirror.css")' />
     <link rel="stylesheet" href='@routes.Assets.at("stylesheets/classes.css")'>
-    <link rel="stylesheet" href='@routes.Assets.at("stylesheets/widgets.css")' />
-    <link rel="stylesheet" href='@routes.Assets.at("stylesheets/classic.css")' />
     <link rel="stylesheet" href='@routes.Assets.at("stylesheets/netlogo-syntax.css")' />
-    <link rel="stylesheet" href='@routes.Assets.at("stylesheets/spinner.css")' />
   </head>
   <body>
-    @views.html.spinner()
     <div class="dynamic-row" style="margin-bottom: 20px; max-width: 900px;">
       <div style="width: 320px;">
         <h3>Find a Built-In Model</h3>
@@ -24,55 +19,31 @@
         <input id="model-file-input" type="file" name="model" />
       </div>
     </div>
-    <div id="model-container" class="model-container"></div>
+    <iframe id="model-container" class="model-container" src="about:blank"></iframe>
   </body>
   <script src='@routes.Assets.at("lib/jquery/jquery.js")' type="text/javascript"></script>
   <script src='@routes.Assets.at("lib/chosen/chosen.jquery.js")' type="text/javascript"></script>
   <script src='@routes.Assets.at("lib/filesaver.js/FileSaver.js")' type="text/javascript"></script>
-  <script src="@routes.Assets.at("lib/markdown-js/markdown.js")"></script>
-  <script src="@routes.Assets.at("lib/highcharts/adapters/standalone-framework.js")"></script>
-  <script src="@routes.Assets.at("lib/highcharts/highcharts.js")"></script>
-  <script src="@routes.Assets.at("lib/highcharts/modules/exporting.js")"></script>
-  <script src="@routes.Assets.at("lib/ractive/ractive.js")"></script>
-  <script src="@routes.Assets.at("lib/codemirror/lib/codemirror.js")"></script>
-  <script src="@routes.Assets.at("lib/codemirror/addon/mode/simple.js")"></script>
   <script>
     var exports = {};
   </script>
   <script type="text/javascript" src='@routes.Assets.at("javascripts/models.js")'></script>
-  <script src="@routes.Local.engine"></script>
-  <script src="@routes.Assets.at("javascripts/TortoiseJS/agent/colors.js")"></script>
-  <script src="@routes.Assets.at("javascripts/TortoiseJS/agent/drawshape.js")"></script>
-  <script src="@routes.Assets.at("javascripts/TortoiseJS/agent/defaultshapes.js")"></script>
-  <script src="@routes.Assets.at("javascripts/TortoiseJS/agent/linkdrawer.js")"></script>
-  <script src="@routes.Assets.at("javascripts/TortoiseJS/agent/view.js")"></script>
-  <script src="@routes.Assets.at("javascripts/TortoiseJS/agent/editor.js")"></script>
-  <script src="@routes.Assets.at("javascripts/TortoiseJS/agent/info.js")"></script>
-  <script src="@routes.Assets.at("javascripts/TortoiseJS/agent/output.js")"></script>
-  <script src="@routes.Assets.at("javascripts/TortoiseJS/agent/console.js")"></script>
-  <script src="@routes.Assets.at("javascripts/TortoiseJS/agent/widgets.js")"></script>
-  <script src="@routes.CompilerService.netLogoWeb"></script>
-  <script src="@routes.Assets.at("javascripts/TortoiseJS/control/session-lite.js")"></script>
-  <script src="@routes.Assets.at("javascripts/plot/highchartsops.js")"></script>
   <script>
     var modelContainer = document.querySelector('#model-container');
-    var session        = null; // initialized in callback;
     var hostPrefix     = location.protocol + '//' + location.host;
-    var url            = hostPrefix + '/assets/modelslib/Sample%20Models/Biology/Wolf%20Sheep%20Predation.nlogo';
+    var url            = "@routes.Assets.at("modelslib/Sample Models/Biology/Wolf Sheep Predation.nlogo").absoluteURL"
     if (window.location.hash) {
       url = window.location.hash.substring(1);
     }
 
     document.querySelector('#model-file-input').addEventListener('change', function (event) {
       var reader = new FileReader();
-      reader.onloadstart = function (e) {
-        Tortoise.startLoading();
-      };
       reader.onload = function (e) {
         openNlogo(e.target.result);
       };
       reader.readAsText(this.files[0]);
     });
+
 
     function pickModel(url) {
       var encoded = encodeURI(hostPrefix + '/assets/' + url);
@@ -84,25 +55,21 @@
       if (decodeURI(url) === url) {
         url = encodeURI(url);
       }
-      if (session) {
-        session.teardown();
-      }
-      Tortoise.fromURL(url, modelContainer, function (res) {
-        session = res;
-        session.startLoop();
-      });
+      modelContainer.src = "/web?"+url;
     }
+
+    window.addEventListener("message", function(e) {
+      modelContainer.width = e.data.width;
+      modelContainer.height = e.data.height;
+    });
 
     function openNlogo(nlogoContents) {
       window.location.hash = "";
-      if (session) {
-        session.teardown();
-      }
       filePath = $("#model-file-input")[0].value;
-      Tortoise.fromNlogo(nlogoContents, modelContainer, filePath, function (res) {
-        session = res;
-        session.startLoop();
-      });
+      modelContainer.contentWindow.postMessage({
+        nlogo: nlogoContents,
+        path: filePath
+      }, "*");
     }
 
     exports.bindModelChooser($('.model-list'), pickModel, '@currentMode');

--- a/app/views/tortoise.scala.html
+++ b/app/views/tortoise.scala.html
@@ -22,60 +22,60 @@
       </div>
     </div>
     <iframe id="model-container" class="model-container" src="about:blank"></iframe>
-  </body>
-  <script src='@routes.Assets.at("lib/jquery/jquery.js")' type="text/javascript"></script>
-  <script src='@routes.Assets.at("lib/chosen/chosen.jquery.js")' type="text/javascript"></script>
-  <script src='@routes.Assets.at("lib/filesaver.js/FileSaver.js")' type="text/javascript"></script>
-  <script>
-    var exports = {};
-  </script>
-  <script type="text/javascript" src='@routes.Assets.at("javascripts/models.js")'></script>
-  <script>
-    var modelContainer = document.querySelector('#model-container');
-    var hostPrefix     = location.protocol + '//' + location.host;
-    var url            = "@routes.Assets.at("modelslib/Sample Models/Biology/Wolf Sheep Predation.nlogo").absoluteURL"
-    if (window.location.hash) {
-      url = window.location.hash.substring(1);
-    }
-
-    document.querySelector('#model-file-input').addEventListener('change', function (event) {
-      var reader = new FileReader();
-      reader.onload = function (e) {
-        openNlogo(e.target.result);
-      };
-      reader.readAsText(this.files[0]);
-    });
-
-
-    function pickModel(url) {
-      var encoded = encodeURI(hostPrefix + '/assets/' + url);
-      openURL(encoded);
-    }
-
-    function openURL(url) {
-      window.location.hash = url;
-      if (decodeURI(url) === url) {
-        url = encodeURI(url);
+    <script src='@routes.Assets.at("lib/jquery/jquery.js")' type="text/javascript"></script>
+    <script src='@routes.Assets.at("lib/chosen/chosen.jquery.js")' type="text/javascript"></script>
+    <script src='@routes.Assets.at("lib/filesaver.js/FileSaver.js")' type="text/javascript"></script>
+    <script>
+      var exports = {};
+    </script>
+    <script type="text/javascript" src='@routes.Assets.at("javascripts/models.js")'></script>
+    <script>
+      var modelContainer = document.querySelector('#model-container');
+      var hostPrefix     = location.protocol + '//' + location.host;
+      var url            = "@routes.Assets.at("modelslib/Sample Models/Biology/Wolf Sheep Predation.nlogo").absoluteURL"
+      if (window.location.hash) {
+        url = window.location.hash.substring(1);
       }
-      modelContainer.src = "/web?"+url;
-    }
 
-    window.addEventListener("message", function(e) {
-      modelContainer.width = e.data.width;
-      modelContainer.height = e.data.height;
-    });
+      document.querySelector('#model-file-input').addEventListener('change', function (event) {
+        var reader = new FileReader();
+        reader.onload = function (e) {
+          openNlogo(e.target.result);
+        };
+        reader.readAsText(this.files[0]);
+      });
 
-    function openNlogo(nlogoContents) {
-      window.location.hash = "";
-      filePath = $("#model-file-input")[0].value;
-      modelContainer.contentWindow.postMessage({
-        nlogo: nlogoContents,
-        path: filePath
-      }, "*");
-    }
 
-    exports.bindModelChooser($('.model-list'), pickModel, '@currentMode');
+      function pickModel(url) {
+        var encoded = encodeURI(hostPrefix + '/assets/' + url);
+        openURL(encoded);
+      }
 
-    openURL(url);
-  </script>
+      function openURL(url) {
+        window.location.hash = url;
+        if (decodeURI(url) === url) {
+          url = encodeURI(url);
+        }
+        modelContainer.src = "/web?"+url;
+      }
+
+      window.addEventListener("message", function(e) {
+        modelContainer.width = e.data.width;
+        modelContainer.height = e.data.height;
+      });
+
+      function openNlogo(nlogoContents) {
+        window.location.hash = "";
+        filePath = $("#model-file-input")[0].value;
+        modelContainer.contentWindow.postMessage({
+          nlogo: nlogoContents,
+          path: filePath
+        }, "*");
+      }
+
+      exports.bindModelChooser($('.model-list'), pickModel, '@currentMode');
+
+      openURL(url);
+    </script>
+  </body>
 </html>

--- a/app/views/tortoise.scala.html
+++ b/app/views/tortoise.scala.html
@@ -5,18 +5,20 @@
     <title>NetLogo Web</title>
     <link rel="stylesheet" href='@routes.Assets.at("lib/chosen/chosen.css")' />
     <link rel="stylesheet" href='@routes.Assets.at("stylesheets/classes.css")'>
+    <link rel="stylesheet" href='@routes.Assets.at("stylesheets/tortoise.css")'>
     <link rel="stylesheet" href='@routes.Assets.at("stylesheets/netlogo-syntax.css")' />
   </head>
   <body>
-    <div class="dynamic-row" style="margin-bottom: 20px; max-width: 900px;">
-      <div style="width: 320px;">
-        <h3>Find a Built-In Model</h3>
-        <div class="model-list tortoise-model-list" style="width: 300px"></div>
+    <div class="model-selection-bar">
+      <div>
+        <label>Find a Built-In Model:
+          <span class="model-list tortoise-model-list"></span>
+        </label>
       </div>
-      <h3 style="width: 30px;"> or </h3>
-      <div style="">
-        <h3>Upload a Model</h3>
-        <input id="model-file-input" type="file" name="model" />
+      <div>
+        <label>Upload a Model:
+          <input id="model-file-input" type="file" name="model" />
+        </label>
       </div>
     </div>
     <iframe id="model-container" class="model-container" src="about:blank"></iframe>

--- a/build.sbt
+++ b/build.sbt
@@ -24,6 +24,7 @@ lazy val root = (project in file(".")).enablePlugins(PlayScala, org.nlogo.PlaySc
 val tortoiseVersion = "0.1-5bbc988"
 
 libraryDependencies ++= Seq(
+  filters,
   "org.nlogo" % "tortoise" % tortoiseVersion,
   "org.nlogo" % "netlogowebjs" % tortoiseVersion,
   cache,

--- a/build.sbt
+++ b/build.sbt
@@ -64,7 +64,17 @@ includeFilter in autoprefixer := Def.setting {
 
 routesGenerator := InjectedRoutesGenerator
 
-scrapeRoutes ++= Seq("/create-standalone", "/info", "/tortoise", "/model/list.json", "/model/statuses.json", "/netlogo-engine.js", "/netlogo-agentmodel.js", "/netlogoweb.js")
+scrapeRoutes ++= Seq(
+  "/info",
+  "/model/list.json",
+  "/model/statuses.json",
+  "/netlogo-engine.js",
+  "/netlogo-agentmodel.js",
+  "/netlogoweb.js",
+  "/standalone",
+  "/tortoise",
+  "/web"
+  )
 
 scrapeDelay := 60
 
@@ -101,3 +111,5 @@ scrapePublishDistributionID <<= Def.settingDyn {
   else
     Def.setting { branchPublish.get("master") }
 }
+
+scrapeAbsoluteURL := Some("netlogoweb.org")

--- a/conf/routes
+++ b/conf/routes
@@ -11,6 +11,8 @@ GET         /model/$modelPath<.*\.nlogo>        controllers.Application.model(mo
 # Local (Tortoise)
 GET         /create-standalone                  controllers.Local.createStandaloneTortoise
 GET         /tortoise                           controllers.Local.tortoise
+GET         /web                                controllers.Local.web
+GET         /standalone                         controllers.Local.standalone
 
 # Compiler Service
 POST        /compile-url                        controllers.CompilerService.compileURL

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -29,4 +29,4 @@ resolvers += Resolver.url(
     url("http://dl.bintray.com/content/netlogo/play-scraper"))(
         Resolver.ivyStylePatterns)
 
-addSbtPlugin("org.nlogo" % "play-scraper" % "0.5")
+addSbtPlugin("org.nlogo" % "play-scraper" % "0.6.0")

--- a/public/stylesheets/classes.css
+++ b/public/stylesheets/classes.css
@@ -37,20 +37,6 @@
   height: 100%;
 }
 
-.model-container {
-    border: 2px solid black;
-    border-radius: 20px;
-    display: inline-block;
-    overflow: hidden;
-    /* In chrome, border-radius lets content bleed through on the corners
-     * despite overflow: hidden, which looks awful with the loading animation.
-     * This mask fixes that.
-     * Found here: http://stackoverflow.com/a/10296258/145080
-     * BCH 7/25/2015
-     **/
-    -webkit-mask-image: url(data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAIAAACQd1PeAAAAGXRFWHRTb2Z0d2FyZQBBZG9iZSBJbWFnZVJlYWR5ccllPAAAAA5JREFUeNpiYGBgAAgwAAAEAAGbA+oJAAAAAElFTkSuQmCC);
-}
-
 .contained {
   height: 92%;
   min-height: 92%;

--- a/public/stylesheets/classes.css
+++ b/public/stylesheets/classes.css
@@ -41,6 +41,14 @@
     border: 2px solid black;
     border-radius: 20px;
     display: inline-block;
+    overflow: hidden;
+    /* In chrome, border-radius lets content bleed through on the corners
+     * despite overflow: hidden, which looks awful with the loading animation.
+     * This mask fixes that.
+     * Found here: http://stackoverflow.com/a/10296258/145080
+     * BCH 7/25/2015
+     **/
+    -webkit-mask-image: url(data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAIAAACQd1PeAAAAGXRFWHRTb2Z0d2FyZQBBZG9iZSBJbWFnZVJlYWR5ccllPAAAAA5JREFUeNpiYGBgAAgwAAAEAAGbA+oJAAAAAElFTkSuQmCC);
 }
 
 .contained {

--- a/public/stylesheets/spinner.css
+++ b/public/stylesheets/spinner.css
@@ -8,6 +8,9 @@
     top:0;
     left:0;
     position:fixed;
+    display: flex;
+    align-items: center;
+    justify-content: center;
 }
 
 .spinner-img {
@@ -20,9 +23,6 @@
 #spinner {
     height: 50px;
     width:  50px;
-    position: fixed;
-    top: 40%;
-    left: 375px;
     transform-origin: 60% 60%;
     animation-name: spin;
     animation-duration: 1.75s;

--- a/public/stylesheets/tortoise.css
+++ b/public/stylesheets/tortoise.css
@@ -1,0 +1,38 @@
+body {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  margin: 0px;
+  font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif;
+}
+
+.model-selection-bar {
+  display: flex;
+  justify-content: space-around;
+  width: 100%;
+  padding: 5px;
+  margin: 0px;
+  margin-bottom: 10px;
+  background-color: #999;
+  font-size: medium;
+}
+
+.model-list {
+  width: 300px;
+  display: inline-block;
+}
+
+.model-container {
+  border: 2px solid black;
+  border-radius: 20px;
+  display: inline-block;
+  overflow: hidden;
+  /* In chrome, border-radius lets content bleed through on the corners
+   * despite overflow: hidden, which looks awful with the loading animation.
+   * This mask fixes that.
+   * Found here: http://stackoverflow.com/a/10296258/145080
+   * BCH 7/25/2015
+   **/
+  -webkit-mask-image: url(data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAIAAACQd1PeAAAAGXRFWHRTb2Z0d2FyZQBBZG9iZSBJbWFnZVJlYWR5ccllPAAAAA5JREFUeNpiYGBgAAgwAAAEAAGbA+oJAAAAAElFTkSuQmCC);
+}
+

--- a/public/stylesheets/widgets.css
+++ b/public/stylesheets/widgets.css
@@ -2,6 +2,9 @@
     display: flex;
     padding: 20px;
     flex-flow: column;
+    font-size: 12px;
+    font-family: "Lucida Grande", sans-serif;
+    outline: none;
 }
 
 .netlogo-header {
@@ -11,8 +14,6 @@
 }
 
 .netlogo-widget {
-    font-size: 12px;
-    font-family: "Lucida Grande", sans-serif;
     box-sizing: border-box;
     background-color: #CCC;
     border-radius: 4px;
@@ -219,6 +220,7 @@
     border: none;
     margin: 0;
     white-space: pre-wrap;
+    font-family: "Lucida Grande", sans-serif;
 }
 
 .netlogo-switcher {


### PR DESCRIPTION
Also adds `/web` and `/standalone` pages that may now be easily used as templates for either non-standalone pages. Loading urls from them is easy:

`/standalone?http://netlogoweb.org/assets/modelslib/Sample%20Models/Art/Follower.nlogo`

As iframes, you can pass nlogo contents to them via a `postMessage`. `/tortoise` does this. Finally, you can also insert the nlogo contents in the `#nlogo-code` element before the pages load. This is how the HTML export works.

Finally, I also made the spinner work a bit better. Since our recompile is now being done synchronously, the spinner never had a chance to come up before the recompile. I made it so the `startLoading` function could asynchronously run the loading process to give the spinner the opportunity to come up.

@TheBizzle, this is ready for review. @mrerrormessage you may want to glance at it as well since it adds another export method and touches the spinner.