### PR TITLE
Update plots when widgets update instead of on every plot command

### DIFF
--- a/app/assets/javascripts/TortoiseJS/agent/widgets.coffee
+++ b/app/assets/javascripts/TortoiseJS/agent/widgets.coffee
@@ -103,6 +103,9 @@ class window.WidgetController
 
   # () -> Unit
   updateWidgets: ->
+    for _, chartOps of @plotOps
+      chartOps.redraw()
+
     for widget, i in @widgets
       if widget.currentValue?
         if widget.varName?

--- a/app/assets/javascripts/plot/highchartsops.coffee
+++ b/app/assets/javascripts/plot/highchartsops.coffee
@@ -53,7 +53,7 @@ class window.HighchartsOps extends PlotOps
       # Wrong, and disabled for performance reasons --JAB (10/19/14)
       # color = @colorToRGBString(pen.getColor())
       # @penToSeries(pen).addPoint({ marker: { fillColor: color }, x: x, y: y })
-      @penToSeries(pen).addPoint([x, y])
+      @penToSeries(pen).addPoint([x, y], false)
       return
 
     updatePenMode = (pen) => (mode) =>
@@ -88,3 +88,6 @@ class window.HighchartsOps extends PlotOps
   # (PenBundle.Pen) => Highcharts.Series
   penToSeries: (pen) ->
     @_chart.series[@_penNameToSeriesNum[pen.name]]
+
+  redraw: ->
+    @_chart.redraw()


### PR DESCRIPTION
This provides a considerable performance increase, particularly noticeable when you push up the speed slider. Plotting Example is a good test model.