### PR TITLE
NLW Error Pages

### DIFF
--- a/app/controllers/Application.scala
+++ b/app/controllers/Application.scala
@@ -24,6 +24,11 @@ class Application extends Controller {
       Ok(views.html.info())
   }
 
+  def serverError: Action[AnyContent] = Action {
+    implicit request =>
+      Ok(views.html.mainTheme(views.html.serverError()))
+  }
+
   def model(modelName: String): Action[AnyContent] = {
     Logger.info("\"%s\" requested".format(modelName))
     Assets.at(path="/public/modelslib", modelName, true)

--- a/app/views/index.scala.html
+++ b/app/views/index.scala.html
@@ -1,6 +1,6 @@
 @views.html.mainTheme {
 
-    <div class="info normal_font rounded" style="background-color: #CDE4EB; padding: 3%;">
+    <div class="normal_font rounded" style="background-color: #CDE4EB; padding: 3%;">
         <div class="dynamic-column-holder">
             <a href="/tortoise" class="index-link flex2">
                 <div class="index-button">

--- a/app/views/mainTheme.scala.html
+++ b/app/views/mainTheme.scala.html
@@ -23,12 +23,8 @@
 
     <div class="core_content_box container not_full_height">
 
-      <div class="content" style="background-color: #347999; height: auto;">
-        <table id="chat" class="full_height" style="table-layout: fixed; width: 100%">
-          <tr>
-          @content
-          </tr>
-        </table>
+      <div class="content" style="background-color: #347999;">
+        @content
       </div>
 
     </div>

--- a/app/views/serverError.scala.html
+++ b/app/views/serverError.scala.html
@@ -1,0 +1,13 @@
+<div style="display: flex; flex-direction: column; justify-content: center; padding: 0 150px; height: 100%;">
+  <div class="normal_font rounded" style="background-color: #CDE4EB; padding: 3%;">
+    <h1 style="margin: auto; text-align: center;">Uh-Oh</h1>
+    <div class="normal_font server-error">
+      There's a problem on our end.
+      <br>
+      <br>
+      We're working to fix it, but we can't say for sure when NetLogo Web will return.
+      <br>
+      In the meantime, why not look through some terrific <a href="http://ccl.northwestern.edu/netlogo/resources.shtml">NetLogo resources</a>?
+    </div>
+  </div>
+</div>

--- a/build.sbt
+++ b/build.sbt
@@ -72,6 +72,7 @@ scrapeRoutes ++= Seq(
   "/netlogo-engine.js",
   "/netlogo-agentmodel.js",
   "/netlogoweb.js",
+  "/server-error",
   "/standalone",
   "/tortoise",
   "/web"

--- a/conf/routes
+++ b/conf/routes
@@ -7,6 +7,7 @@ GET         /                                   controllers.Application.index
 GET         /info                               controllers.Application.info
 GET         /model/list.json                    controllers.Application.modelList
 GET         /model/$modelPath<.*\.nlogo>        controllers.Application.model(modelPath)
+GET         /server-error                       controllers.Application.serverError
 
 # Local (Tortoise)
 GET         /create-standalone                  controllers.Local.createStandaloneTortoise

--- a/public/stylesheets/classes.css
+++ b/public/stylesheets/classes.css
@@ -136,6 +136,12 @@ li.unknown.dev {
   border-top: 1px solid #5499B9;
 }
 
+.server-error {
+  margin-top: 20px;
+  font-size: 20px;
+  line-height: 25px;
+  text-align: center;
+}
 /*
 
  Flexbox stuff


### PR DESCRIPTION
We can customize errors for any / all of these pages. We can build one error page and use it everywhere, or build pages for specific errors. A common practice I've seen is having a 404 page, then a separate page for all other errors, but we could also use just one page "Something went wrong..." or something like that.
<img width="709" alt="screen shot 2015-07-24 at 12 33 52 pm" src="https://cloud.githubusercontent.com/assets/143198/8880721/5ce74aee-3200-11e5-9545-85decdd11773.png">
