### PR TITLE
Default to random model

### DIFF
--- a/app/assets/javascripts/models.coffee
+++ b/app/assets/javascripts/models.coffee
@@ -1,4 +1,4 @@
-exports.bindModelChooser = (container, selectionChanged, currentMode) ->
+exports.bindModelChooser = (container, onComplete, selectionChanged, currentMode) ->
 
   PUBLIC_PATH_SEGMENT_LENGTH = "public/".length
 
@@ -23,7 +23,7 @@ exports.bindModelChooser = (container, selectionChanged, currentMode) ->
         .addClass(status)
 
   populateModelChoices = (select, modelNames) ->
-    select.append($('<option>').text('Select a model...'))
+    select.append($('<option>').text('Select a model'))
     for modelName in modelNames
       option = $('<option>').attr('value', adjustModelPath(modelName))
         .text(modelDisplayName(modelName))
@@ -57,16 +57,35 @@ exports.bindModelChooser = (container, selectionChanged, currentMode) ->
               setModelCompilationStatus(modelName, modelStatus)
             window.modelSelect.trigger('chosen:updated')
         })
-
+      onComplete()
     }
   )
 
-exports.modelList = (container) ->
-  uploadModel = (modelURL) ->
-    $.ajax('assets/' + modelURL, {
-        complete: (req, status) ->
-          if status is 'success'
-            session.open(req.responseText)
-      }
-    )
-  exports.bindModelChooser(container, uploadModel)
+exports.selectModel = (model) ->
+  modelSelect.val(model)
+  modelSelect.trigger("chosen:updated")
+
+exports.handPickedModels = [
+  "Sample Models/Art/Follower",
+  "Sample Models/Biology/Wolf Sheep Predation",
+  "Sample Models/Biology/Ants",
+  "Sample Models/Biology/Flocking",
+  "Sample Models/Biology/Virus",
+  "Sample Models/Biology/Daisyworld",
+  "Sample Models/Biology/Evolution/Cooperation",
+  "Sample Models/Computer Science/Cellular Automata/CA 1D Elementary",
+  "Sample Models/Computer Science/Cellular Automata/Life Turtle-Based",
+  "Sample Models/Earth Science/Fire",
+  "Sample Models/Earth Science/Climate Change",
+  "Sample Models/Mathematics/Mousetraps",
+  "Sample Models/Mathematics/3D Solids",
+  "Sample Models/Networks/Preferential Attachment",
+  "Sample Models/Social Science/Voting",
+  "Sample Models/Social Science/Segregation",
+  "Sample Models/Social Science/Traffic Basic",
+  "Sample Models/Chemistry & Physics/Diffusion Limited Aggregation/DLA",
+  "Sample Models/Chemistry & Physics/Ising",
+  "Sample Models/Chemistry & Physics/GasLab/GasLab Adiabatic Piston",
+  "Sample Models/Chemistry & Physics/Heat/Boiling",
+  "Sample Models/Chemistry & Physics/Waves/Wave Machine"
+].map((p) -> "modelslib/#{p}")

--- a/app/views/tortoise.scala.html
+++ b/app/views/tortoise.scala.html
@@ -38,10 +38,6 @@
   <script>
     var modelContainer = document.querySelector('#model-container');
     var hostPrefix     = location.protocol + '//' + location.host;
-    var url            = "@routes.Assets.at("modelslib/Sample Models/Biology/Wolf Sheep Predation.nlogo").absoluteURL"
-    if (window.location.hash) {
-      url = window.location.hash.substring(1);
-    }
 
     document.querySelector('#model-file-input').addEventListener('change', function (event) {
       var reader = new FileReader();
@@ -55,6 +51,12 @@
     function pickModel(url) {
       var encoded = encodeURI(hostPrefix + '/assets/' + url);
       openURL(encoded);
+    }
+
+    function pickRandom() {
+      var model = exports.handPickedModels[Math.floor(Math.random() * exports.handPickedModels.length)]
+      exports.selectModel(model)
+      pickModel(model + ".nlogo")
     }
 
     function openURL(url) {
@@ -79,9 +81,15 @@
       }, "*");
     }
 
-    exports.bindModelChooser($('.model-list'), pickModel, '@mode.toString.toLowerCase');
+    function initModel() {
+      if (window.location.hash) {
+        openURL(window.location.hash.substring(1));
+      } else {
+        pickRandom();
+      }
+  }
 
-    openURL(url);
+    exports.bindModelChooser($('.model-list'), initModel, pickModel, '@mode.toString.toLowerCase');
   </script>
 }
 

--- a/public/stylesheets/tortoise.css
+++ b/public/stylesheets/tortoise.css
@@ -68,6 +68,15 @@ iframe {
   padding-left:   35px;
 }
 
+.chosen-container-single .chosen-single span {
+  direction: rtl;
+  /* Due to a bug in Chrome, we can't clip left and use ellipses:
+     https://code.google.com/p/chromium/issues/detail?id=171659
+     BCH 8/6/2015 */
+  text-overflow: clip;
+  text-align: left;
+}
+
 li.not_compiling.dev {
   background-image: url('/assets/images/x.png') !important;
 }


### PR DESCRIPTION
Current list:

- Sample Models/Art/Follower
- Sample Models/Biology/Wolf Sheep Predation
- Sample Models/Biology/Ants
- Sample Models/Biology/Flocking
- Sample Models/Biology/Virus
- Sample Models/Biology/Daisyworld
- Sample Models/Biology/Evolution/Cooperation
- Sample Models/Computer Science/Cellular Automata/CA 1D Elementary
- Sample Models/Computer Science/Cellular Automata/Life Turtle-Based
- Sample Models/Earth Science/Fire
- Sample Models/Earth Science/Climate Change
- Sample Models/Mathematics/Mousetraps
- Sample Models/Mathematics/3D Solids
- Sample Models/Networks/Preferential Attachment
- Sample Models/Social Science/Voting
- Sample Models/Social Science/Segregation
- Sample Models/Social Science/Traffic Basic
- Sample Models/Chemistry & Physics/Diffusion Limited Aggregation/DLA
- Sample Models/Chemistry & Physics/Ising
- Sample Models/Chemistry & Physics/GasLab/GasLab Adiabatic Piston
- Sample Models/Chemistry & Physics/Heat/Boiling
- Sample Models/Chemistry & Physics/Waves/Wave Machine

Very open to other suggestions. I was hoping to have more cellular models like B-Z reaction, but decided they were too slow. I didn't put Termites because the way it's written is really expecting continuous display updates (the termites can move for an arbitrary amount of time with each `ask`). 

Should the chooser show the randomly selected model? If the answer is yes, we should realign the selected item in the chooser so that you can actually see the model name, instead of just the category. I couldn't get this to work after messing around for a few minutes.