### PR TITLE
Changes to error reporting to support JVM "export to NetLogo Web"

### DIFF
--- a/app/assets/javascripts/TortoiseJS/control/session-lite.coffee
+++ b/app/assets/javascripts/TortoiseJS/control/session-lite.coffee
@@ -9,7 +9,7 @@ MAX_REDRAW_DELAY     = 1000
 REDRAW_EXP           = 2
 
 class window.SessionLite
-  constructor: (@widgetController, @alerter) ->
+  constructor: (@widgetController, @displayError) ->
     @_eventLoopTimeout = -1
     @_lastRedraw = 0
     @_lastUpdate = 0
@@ -74,7 +74,7 @@ class window.SessionLite
     Tortoise.startLoading( =>
       world.clearAll()
       @widgetController.redraw()
-      codeCompile(@widgetController.code(), [], [], @widgetController.widgets, (res) ->
+      codeCompile(@widgetController.code(), [], [], @widgetController.widgets, (res) =>
         if res.model.success
           globalEval(res.model.result)
         else
@@ -147,7 +147,7 @@ class window.SessionLite
   run: (code) ->
     Tortoise.startLoading()
     codeCompile(@widgetController.code(), [code], [], @widgetController.widgets,
-      (res) ->
+      (res) =>
         success = res.commands[0].success
         result  = res.commands[0].result
         Tortoise.finishLoading()
@@ -157,7 +157,8 @@ class window.SessionLite
           @alertCompileError(result))
 
   alertCompileError: (result) ->
-    alert(result.map((err) -> err.message).join('\n')))
+    alertText = result.map((err) -> err.message).join('\n')
+    @displayError(alertText)
 
 # See http://perfectionkills.com/global-eval-what-are-the-options/ for what
 # this is doing. This is a holdover till we get the model attaching to an

--- a/app/assets/javascripts/TortoiseJS/control/tortoise.coffee
+++ b/app/assets/javascripts/TortoiseJS/control/tortoise.coffee
@@ -1,0 +1,138 @@
+nlogoCompile = (commands, reporters, widgets, onFulfilled) -> (model) ->
+  onFulfilled((new BrowserCompiler()).fromNlogo(model, commands))
+
+loadError = (url) ->
+  """
+    Unable to load NetLogo model from #{url}, please ensure:
+    <ul>
+      <li>That you can download the resource <a target="_blank" href="#{url}">at this link</a></li>
+      <li>That the server containing the resource has
+        <a target="_blank" href="https://en.wikipedia.org/wiki/Cross-origin_resource_sharing">
+          Cross-Origin Resource Sharing
+        </a>
+        configured appropriately</li>
+    </ul>
+    If you have followed the above steps and are still seeing this error,
+    please send an email to our <a href="mailto:bugs@ccl.northwestern.edu">"bugs" mailing list</a>
+    with the following information:
+    <ul>
+      <li>The full URL of this page (copy and paste from address bar)</li>
+      <li>Your operating system and browser version</li>
+    </ul>
+  """
+
+apply = (callback, generator) -> (input) ->
+  callback(generator(input))
+
+# handleAjaxLoad : String, (String) => (), (XMLHttpRequest) => () => Unit
+handleAjaxLoad = (url, onSuccess, onFailure) =>
+  req = new XMLHttpRequest()
+  req.open('GET', url)
+  req.onreadystatechange = () ->
+    if req.readyState == req.DONE
+      if (req.status == 0 || req.status >= 400)
+        onFailure(req)
+      else
+        onSuccess(req.responseText)
+  req.send("")
+
+# handleCompilation : (ModelResult => (), ModelResult => ()) => (String) => ()
+handleCompilation = (onSuccess, onError) ->
+  nlogoCompile([], [], [],
+    (res) =>
+      if res.model.success
+        onSuccess(res)
+      else
+        onError(res))
+
+# newSession: String|DomElement, ModelResult, Boolean, String => SessionLite
+newSession = (container, modelResult, readOnly = false, filename = "export", onError=undefined) ->
+  widgets = globalEval(modelResult.widgets)
+  widgetController = bindWidgets(container, widgets, modelResult.code, modelResult.info, readOnly, filename)
+  window.modelConfig ?= {}
+  modelConfig.plotOps = widgetController.plotOps
+  modelConfig.mouse = widgetController.mouse
+  modelConfig.print = { write: widgetController.write }
+  modelConfig.output = widgetController.output
+  globalEval(modelResult.model.result)
+  new SessionLite(widgetController, onError)
+
+# We separate on both / and \ because we get URLs and Windows-esque filepaths
+normalizedFileName = (path) ->
+  pathComponents = path.split(/\/|\\/)
+  decodeURI(pathComponents[pathComponents.length - 1])
+
+loadData = (container, pathOrURL, loader, onError) ->
+  {
+    container,
+    loader,
+    onError,
+    modelPath: pathOrURL,
+  }
+
+openSession = (load) -> (model) ->
+  filename = normalizedFileName(load.modelPath)
+  session  = newSession(load.container, model, false, filename, load.onError)
+  load.loader.finish()
+  session
+
+# process: function which takes a loader as an argument, producing a function that can be run
+loading = (process) ->
+  document.querySelector("#loading-overlay").style.display = ""
+  loader = {
+    finish: () -> document.querySelector("#loading-overlay").style.display = "none"
+  }
+  setTimeout(process(loader), 20)
+
+defaultDisplayError = (container) ->
+  (errors) -> container.innerHTML = "<div style='padding: 5px 10px;'>#{errors}</div>"
+
+reportCompilerError = (load) -> (res) ->
+  errors = res.model.result.map((err) -> err.message).join('<br/>')
+  load.onError(errors)
+  load.loader.finish()
+
+reportAjaxError = (load) -> (req) ->
+  load.onError(loadError(load.modelPath))
+  load.loader.finish()
+
+# process: optional argument that allows the loading process to be async to
+# give the animation time to come up.
+startLoading = (process) ->
+  document.querySelector("#loading-overlay").style.display = ""
+  # This gives the loading animation time to come up. BCH 7/25/2015
+  if (process?) then setTimeout(process, 20)
+
+finishLoading = ->
+  document.querySelector("#loading-overlay").style.display = "none"
+
+fromNlogo =     (nlogo, container, path, callback, onError = defaultDisplayError(container)) ->
+  loading((loader) ->
+    load = loadData(container, path, loader, onError)
+    handleCompilation(
+      apply(callback, openSession(load)),
+      reportCompilerError(load)
+    )(nlogo)
+  )
+
+fromURL =       (url,   container, callback, onError = defaultDisplayError(container)) ->
+  loading((loader) ->
+    load = loadData(container, url, loader, onError)
+    handleAjaxLoad(url,
+      handleCompilation(
+        apply(callback, openSession(load)),
+        reportCompilerError(load)),
+      reportAjaxError(load))
+  )
+
+window.Tortoise = {
+  startLoading,
+  finishLoading,
+  fromNlogo,
+  fromURL
+}
+
+# See http://perfectionkills.com/global-eval-what-are-the-options/ for what
+# this is doing. This is a holdover till we get the model attaching to an
+# object instead of global namespace. - BCH 11/3/2014
+globalEval = eval

--- a/app/assets/javascripts/alert.coffee
+++ b/app/assets/javascripts/alert.coffee
@@ -1,0 +1,21 @@
+class window.NLWAlerter
+  constructor: (alertFrame, @isStandalone) ->
+    @alertWindow = $(alertFrame)
+    @alertContainer = $(alertFrame).find("#alert-dialog").get(0)
+
+  display: (title, dismissable, content) ->
+    @alertWindow.find("#alert-title").text(title)
+    @alertWindow.find("#alert-message").html(content)
+    if @isStandalone
+      $(".standalone-text").show()
+    if ! dismissable
+      @alertWindow.find("#alert-dismiss-container").hide()
+    else
+      @alertWindow.find("#alert-dismiss-container").show()
+    @alertWindow.show()
+
+  displayError: (content, dismissable=true, title="Error") ->
+    @display(title, dismissable, content)
+
+  hide: () ->
+    @alertWindow.hide()

--- a/app/controllers/CompilerService.scala
+++ b/app/controllers/CompilerService.scala
@@ -325,6 +325,7 @@ private[controllers] trait RequestResultGenerator {
         "javascripts/TortoiseJS/agent/console.js",
         "javascripts/TortoiseJS/agent/widgets.js",
         "javascripts/TortoiseJS/communication/connection.js",
+        "javascripts/TortoiseJS/control/tortoise.js",
         "javascripts/TortoiseJS/control/session-lite.js",
         "javascripts/plot/highchartsops.js"
       ).map(path => s"/public/$path")

--- a/app/views/errorAlert.scala.html
+++ b/app/views/errorAlert.scala.html
@@ -1,0 +1,21 @@
+<div class="dark-overlay" id="alert-overlay" style="display : none ;">
+    <div id="alert-dialog">
+        <h3 id="alert-title">Error</h3>
+        @* Text in the #alert-message div will be replaced by the alert js *@
+        <div id="alert-message" class="alert-text">
+            NetLogo Web has encountered a problem.
+        </div>
+        <div class="alert-text standalone-text">
+            It looks like you're using NetLogo Web in standalone mode.
+            <br />
+            If the above error is being caused by a missing primitive, we recommend a quick visit to
+                <a href="http://netlogoweb.org" target="_blank">NetLogoWeb.org</a>.
+                to see if the primitive has been implemented in the most up-to-date version.
+        </div>
+        <div id="alert-dismiss-container">
+            <button id="alert-dismiss" class="alert-button alert-separator-top" onclick="nlwAlerter.hide()">
+                Dismiss
+            </button>
+        </div>
+    </div>
+</div>

--- a/app/views/simulation.scala.html
+++ b/app/views/simulation.scala.html
@@ -40,6 +40,7 @@
     @script(route("javascripts/TortoiseJS/agent/console.js"))
     @script(route("javascripts/TortoiseJS/agent/title.js"))
     @script(route("javascripts/TortoiseJS/agent/widgets.js"))
+    @script(route("javascripts/TortoiseJS/control/tortoise.js"))
     @script(route("javascripts/TortoiseJS/control/session-lite.js"))
     @script(route("javascripts/plot/highchartsops.js"))
 

--- a/app/views/simulation.scala.html
+++ b/app/views/simulation.scala.html
@@ -11,9 +11,11 @@
     @style(route("stylesheets/netlogoweb.css"))
     @style(route("stylesheets/netlogo-syntax.css"))
     @style(route("stylesheets/spinner.css"))
+    @style(route("stylesheets/alert.css"))
   </head>
   <body style="margin: 0px;">
     @views.html.spinner()
+    @views.html.errorAlert()
     <div id="netlogo-model-container" style="display: inline-block;"></div>
     @script(route("lib/jquery/jquery.js"))
     @script(route("lib/filesaver.js/FileSaver.js"))
@@ -43,6 +45,7 @@
     @script(route("javascripts/TortoiseJS/control/tortoise.js"))
     @script(route("javascripts/TortoiseJS/control/session-lite.js"))
     @script(route("javascripts/plot/highchartsops.js"))
+    @script(route("javascripts/alert.js"))
 
     @helper.javascriptRouter("jsRoutes")(
       routes.javascript.Local.standalone
@@ -52,11 +55,13 @@
     <script type="text/nlogo" id="nlogo-code" data-filename="model.nlogo"></script>
 
     <script>
-      var modelContainer = document.querySelector("#netlogo-model-container");
-      var index          = window.location.href.indexOf("?");
-      var nlogoScript    = document.querySelector("#nlogo-code");
-      var standaloneURL  = "@routes.Local.standalone.absoluteURL";
-      var pageTitle      = function(modelTitle) {
+      var loadingOverlay  = $("#loading-overlay").get(0);
+      var activeContainer = loadingOverlay;
+      var modelContainer  = document.querySelector("#netlogo-model-container");
+      var index           = window.location.href.indexOf("?");
+      var nlogoScript     = document.querySelector("#nlogo-code");
+      var standaloneURL   = "@routes.Local.standalone.absoluteURL";
+      var pageTitle       = function(modelTitle) {
         if (modelTitle != null && modelTitle != "") {
           return "NetLogo Web: " + modelTitle;
         } else {
@@ -67,36 +72,63 @@
       var openSession = function(s) {
         session = s;
         document.title = pageTitle(session.modelTitle());
+        activeContainer = modelContainer;
         session.startLoop();
       };
 
+      var isStandaloneHTML = false;
+
       if (nlogoScript.textContent.length > 0) {
-        Tortoise.fromNlogo(nlogoScript.textContent, modelContainer, nlogoScript.dataset.filename, openSession);
+        isStandaloneHTML = true;
+      }
+
+      var nlwAlerter     = new NLWAlerter($("#alert-overlay"), isStandaloneHTML);
+
+      var displayError = function(error) {
+        // in the case where we're still loading the model, we have to
+        // post an error that cannot be dismissed, as well as ensuring that
+        // the frame we're in matches the size of the error on display.
+        if (activeContainer == loadingOverlay) {
+          nlwAlerter.displayError(error, false);
+          activeContainer = nlwAlerter.alertContainer;
+        } else {
+          nlwAlerter.displayError(error);
+        }
+      };
+
+      if (nlogoScript.textContent.length > 0) {
+        Tortoise.fromNlogo(nlogoScript.textContent,
+                           modelContainer,
+                           nlogoScript.dataset.filename,
+                           openSession,
+                           displayError);
       } else if (index > -1) {
         var url = window.location.href.substring(index+1);
         console.log(url);
-        Tortoise.fromURL(url, modelContainer, openSession);
+        Tortoise.fromURL(url, modelContainer, openSession, displayError);
       }
 
       window.addEventListener("message", function (e) {
         if (session) {
           session.teardown();
         }
-        Tortoise.fromNlogo(e.data.nlogo, modelContainer, e.data.path, openSession);
+        Tortoise.fromNlogo(e.data.nlogo, modelContainer, e.data.path, openSession, displayError);
       });
 
       if (parent !== window) {
         var width = "", height = "";
         window.setInterval(function() {
-          if (modelContainer.scrollWidth  !== width ||
-              modelContainer.scrollHeight !== height ||
+          if (activeContainer.scrollWidth  !== width ||
+              activeContainer.scrollHeight !== height ||
               (session !== undefined && document.title != pageTitle(session.modelTitle()))) {
-            document.title = pageTitle(session.modelTitle());
-            width = modelContainer.scrollWidth;
-            height = modelContainer.scrollHeight;
+            if (session !== undefined) {
+              document.title = pageTitle(session.modelTitle());
+            }
+            width = activeContainer.scrollWidth;
+            height = activeContainer.scrollHeight;
             parent.postMessage({
-              width:  modelContainer.scrollWidth,
-              height: modelContainer.scrollHeight,
+              width:  activeContainer.scrollWidth,
+              height: activeContainer.scrollHeight,
               title:  document.title
             }, "*");
           }

--- a/app/views/spinner.scala.html
+++ b/app/views/spinner.scala.html
@@ -1,4 +1,4 @@
-<div id="loading-overlay">
+<div class="dark-overlay" id="loading-overlay">
   <div id="spinner">
     @for(i <- 1 to 8) {
       <svg class="spinner-img turtle@i" xmlns="http://www.w3.org/2000/svg" version="1.1" viewBox="0 0 50 55">

--- a/app/views/standaloneTortoise.scala.html
+++ b/app/views/standaloneTortoise.scala.html
@@ -21,10 +21,15 @@
       @Html(js)
       var session =
         (function () {
-          var widgets = @Html(widgets);
-          var code    = "@clean(nlogoCode)";
-          var info    = "@clean(info)";
-          return Tortoise.fromCompiledModel('#netlogo-model-container', widgets, code, info, '', true);
+          var modelResult = {
+            widgets: @Html(widgets),
+            code:    "@clean(nlogoCode)",
+            info:    "@clean(info)",
+            model:   {
+                result: ''
+            }
+          };
+          return Tortoise.openSession('#netlogo-model-container', modelResult, '', true);
         })();
       @Html(libsJs)
       session.startLoop()

--- a/public/stylesheets/alert.css
+++ b/public/stylesheets/alert.css
@@ -1,0 +1,60 @@
+/*
+ * styles to use with the "error alert" component
+ */
+
+.dark-overlay {
+  background-color:rgba(0, 0, 0, 0.7);
+  width:100%;
+  height:100%;
+  z-index:10;
+  top:0;
+  left:0;
+  position: fixed;
+}
+
+#alert-overlay {
+  display: flex;
+  flex-direction: row;
+  justify-content: center;
+  align-items: center;
+}
+
+#alert-dialog {
+  background-color: whitesmoke;
+  opacity: 1;
+  z-index: 15;
+  border-radius: 10px;
+  border: 2px black solid;
+  display:flex;
+  flex-direction: column;
+  align-items: center;
+}
+
+#alert-title {
+  margin-bottom: 5px;
+}
+
+.alert-text {
+  padding: 10px;
+}
+
+.standalone-text {
+  display: none;
+  text-align: center;
+  max-width: 80%;
+}
+
+#alert-dismiss-container {
+  border-top: 1px solid lightgray;
+  width: 100%;
+  text-align: center;
+  padding: 10px 0;
+}
+
+.alert-button {
+  height: 25px;
+  min-width: 50%;
+  border-radius: 3px;
+  border: 1px solid lightgray;
+  background-color: #e6e6e6;
+}

--- a/public/stylesheets/spinner.css
+++ b/public/stylesheets/spinner.css
@@ -3,15 +3,6 @@
  */
 
 #loading-overlay {
-  opacity:0.7;
-  filter: alpha(opacity=20);
-  background-color:#000;
-  width:100%;
-  height:100%;
-  z-index:10;
-  top:0;
-  left:0;
-  position:fixed;
   display: flex;
   align-items: center;
   justify-content: center;


### PR DESCRIPTION
Adds a new view error component, which is a lightbox overlay (like the spinner) and displays errors in place of `window.alert`. The reason to switch is to allow links within the error (not possible using alert).

The component is the same regardless of the error situation, but there are basically four error cases where the look is somewhat distinctive:

1. Online Mode, error when loading model
2. Online Mode, error after model loaded
3. Exported Mode, error when loading model
4. Exported Mode, error after model loaded

Find screencaps of each situation below. 

1. Online Mode, error when loading model
<img width="979" alt="screen shot 2015-08-31 at 10 18 37 am" src="https://cloud.githubusercontent.com/assets/143198/9582437/f9307b54-4fca-11e5-90ec-21f5df1d30ef.png">

2. Online Mode, error after model loaded
<img width="844" alt="screen shot 2015-08-31 at 10 20 03 am" src="https://cloud.githubusercontent.com/assets/143198/9582419/df955692-4fca-11e5-9e7e-b14c9794942b.png">

3. Exported Mode, error when loading model
<img width="1264" alt="screen shot 2015-08-31 at 10 20 20 am" src="https://cloud.githubusercontent.com/assets/143198/9582462/1a26ee38-4fcb-11e5-8bb2-81975f13da9f.png">

4. Exported Mode, error after model loaded
<img width="1314" alt="screen shot 2015-08-31 at 10 21 27 am" src="https://cloud.githubusercontent.com/assets/143198/9582472/291401a6-4fcb-11e5-86d6-bf337e87c345.png">


