### PR TITLE
Restyle error alert box to foreground actual error

### DIFF
--- a/app/views/errorAlert.scala.html
+++ b/app/views/errorAlert.scala.html
@@ -8,8 +8,8 @@
         <div class="alert-text standalone-text">
             It looks like you're using NetLogo Web in standalone mode.
             <br />
-            If the above error is being caused by a missing primitive, we recommend a quick visit to
-                <a href="http://netlogoweb.org" target="_blank">NetLogoWeb.org</a>.
+            If the above error is being caused by an unimplemented primitive, we recommend a quick visit to
+                <a href="http://netlogoweb.org" target="_blank">NetLogoWeb.org</a>
                 to see if the primitive has been implemented in the most up-to-date version.
         </div>
         <div id="alert-dismiss-container">

--- a/build.sbt
+++ b/build.sbt
@@ -21,7 +21,7 @@ scalacOptions ++= Seq(
 
 lazy val root = (project in file(".")).enablePlugins(PlayScala, org.nlogo.PlayScrapePlugin)
 
-val tortoiseVersion = "1.0-f3bb854"
+val tortoiseVersion = "1.0-ff0fb51"
 
 libraryDependencies ++= Seq(
   filters,

--- a/public/stylesheets/alert.css
+++ b/public/stylesheets/alert.css
@@ -17,6 +17,7 @@
   flex-direction: row;
   justify-content: center;
   align-items: center;
+  font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif;
 }
 
 #alert-dialog {
@@ -36,12 +37,14 @@
 
 .alert-text {
   padding: 10px;
+  font-size: 16px;
 }
 
 .standalone-text {
+  color: #555555;
   display: none;
   text-align: center;
-  max-width: 80%;
+  max-width: 600px;
 }
 
 #alert-dismiss-container {
@@ -52,6 +55,7 @@
 }
 
 .alert-button {
+  font-size: 14px;
   height: 25px;
   min-width: 50%;
   border-radius: 3px;


### PR DESCRIPTION
Now looks like:

![screen shot 2015-09-02 at 11 43 35 am](https://cloud.githubusercontent.com/assets/143198/9637907/1b90ced4-5169-11e5-891c-59a69efe1855.png)

Depends on https://github.com/NetLogo/Tortoise/pull/171.