### PR TITLE
fix multiline inputbox issue

### DIFF
--- a/app/assets/javascripts/TortoiseJS/agent/component/input.coffee
+++ b/app/assets/javascripts/TortoiseJS/agent/component/input.coffee
@@ -15,7 +15,13 @@ window.RactiveInput = Ractive.extend({
            style="{{dims}}">
       <div class="netlogo-label">{{widget.varName}}</div>
       {{# widget.boxtype === 'Number'}}<input type="number" value="{{widget.currentValue}}" />{{/}}
-      {{# widget.boxtype === 'String'}}<input type="text" value="{{widget.currentValue}}" />{{/}}
+      {{# widget.boxtype === 'String'}}
+        {{#if widget.multiline === false}}
+          <input type="text" value="{{widget.currentValue}}" />
+        {{else}}
+          <textarea rows="4">{{widget.currentValue}}</textarea>
+        {{/if}}
+      {{/}}
       {{# widget.boxtype === 'String (reporter)'}}<input type="text" value="{{widget.currentValue}}" />{{/}}
       {{# widget.boxtype === 'String (commands)'}}<input type="text" value="{{widget.currentValue}}" />{{/}}
       <!-- TODO: Fix color input. It'd be nice to use html5s color input. -->


### PR DESCRIPTION
To fix issue #313 

I find that I should make pull request to https://github.com/qiemem/TortoiseJS in [the wiki](https://github.com/NetLogo/Galapagos/wiki/TortoiseJS), however, it is out of date. So I make a pull request to here.


Now multiline inputbox is available(using `<textarea>`). However, there is still a problem that `widget.multiline` is always `true`.