### PR TITLE
Build/deploy script should error on scrape failure

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,10 +17,8 @@ script:
   - "sbt scalastyle"
   - "sbt coffeelint"
   - "sbt test"
-
-after_success:
-  - sbt scrapePlay
-  - sbt scrapeUpload
+  - "sbt scrapePlay"
+  - "sbt scrapeUpload"
 
 env:
   global:


### PR DESCRIPTION
Recently, I upgraded this repo to use Play 2.5 (which just came out).  I updated the code in the Galapagos repo, but (unbeknownst to me) the Play-Scraper plugin was no longer compatible with the contents of this repo.  When Travis went to run the tests, it tried to scrape the page for the site, failed on an exception, kept going, pushed up the failed scrape, and told me that the build had passed entirely successfully.  A couple of days later, I discover that netlogoweb.org homepage has been blanked this whole while, because of the failed scrape.  Not cool.

The Travis script needs to be configured to not continue with the upload when scraping fails, to report scraping failures as build errors.

Assigning @mrerrormessage