### PR TITLE
https://netlogoweb.org/ needed

### DIFF
--- a/app/controllers/TagBuilder.scala
+++ b/app/controllers/TagBuilder.scala
@@ -59,17 +59,18 @@ object InlineTagBuilder extends TagBuilder {
 object OutsourceTagBuilder extends TagBuilder {
 
   override def pathToHTML(path: String)(implicit request: Request[_], environment: Environment): Html =
-    genTag(routes.Assets.at(path).absoluteURL)
+    genTag(new URL(routes.Assets.at(path).absoluteURL))
 
   override def callToHTML(call: Call, resourcePath: String)(implicit request: Request[_], environment: Environment): Html =
-    genTag(call.absoluteURL)
+    genTag(new URL(call.absoluteURL))
 
-  private def genTag(url: String): Html = {
+  private def genTag(url: URL): Html = {
+    val protoRelativeURL = s"//${url.getAuthority}${url.getFile}"
     val FileExtensionRegex      = ".*\\.(.*)$".r
-    val FileExtensionRegex(ext) = url
+    val FileExtensionRegex(ext) = url.getPath
     ext match {
-      case "js"  => Html(s"""<script src="$url"></script>""")
-      case "css" => Html(s"""<link rel="stylesheet" href="$url"></link>""")
+      case "js"  => Html(s"""<script src="$protoRelativeURL"></script>""")
+      case "css" => Html(s"""<link rel="stylesheet" href="$protoRelativeURL"></link>""")
       case x     => throw new Exception(s"We don't know how to build a tag for '.$x' files")
     }
   }


### PR DESCRIPTION
_From @ToonTalk on March 18, 2016 11:17_

> You can link to http://netlogoweb.org/web?modelURL (where modelURL is the URL of your model). Everytime someone goes to that link (or an iframe is loaded that uses that link as the source URL), the most recent version of your model will be fetched from modelURL and turned into a simple model page.

If the one follows this advice on http://www.netlogoweb.org/info and uses such a URL in an iframe then if the containing web page is https and not http it will not display. At least in Chrome the console shows:

Mixed Content: The page at 'https://788-dot-m4a-gae-hrd.appspot.com/m/?EGM=1&share=HvI-ZK5J7DUnvNGOvqGG…odel.%20Has%20been%20loaded%20374%20times%20before%20and%20run%207%20times.)' was loaded over HTTPS, but requested an insecure resource 'http://www.netlogoweb.org/launch'. This request has been blocked; the content must be served over HTTPS.

_Copied from original issue: NetLogo/Tortoise#179_