### PR TITLE
Input box template should not bind multiline value for editing on non…

### DIFF
--- a/app/assets/javascripts/TortoiseJS/agent/component/input.coffee
+++ b/app/assets/javascripts/TortoiseJS/agent/component/input.coffee
@@ -127,8 +127,11 @@ window.RactiveInput = RactiveWidget.extend({
     """
     {{>input}}
     {{>contextMenu}}
-    <editForm idBasis="{{id}}" boxtype="{{widget.boxedValue.type}}"
-              display="{{widget.display}}" isMultiline="{{widget.boxedValue.multiline}}" />
+    <editForm idBasis="{{id}}" boxtype="{{widget.boxedValue.type}}" display="{{widget.display}}"
+              {{# widget.boxedValue.type !== 'Color' && widget.boxedValue.type !== 'Number' }}
+                isMultiline="{{widget.boxedValue.multiline}}"
+              {{/}}
+              />
     """
 
   # coffeelint: disable=max_line_length


### PR DESCRIPTION
…-String input types

This change is actually to fix [Tortoise issue 182 about error messages when using the command center](https://github.com/NetLogo/Tortoise/issues/182).  Updated the change to be for the input box multiline property only, per the comments on the [previous PR off of the wrong branch](https://github.com/NetLogo/Galapagos/pull/368).  I tested the change manually in Firefox and Chrome and no longer receive the input box error when using the command center, as expected.  
