### PR TITLE
Fix wrong path of CodeMirror assets

### DIFF
--- a/app/controllers/Application.scala
+++ b/app/controllers/Application.scala
@@ -62,7 +62,7 @@ class Application @Inject() ( assets: Assets
     def linkTag(x: String)   = s"""<link rel="stylesheet" media="screen" href="$x">"""
     def scriptTag(x: String) = s"""<script src="$x"></script>"""
 
-    val cssURLs = Seq( "lib/codemirror/lib/codemirror"
+    val cssURLs = Seq( "codemirror/lib/codemirror"
                      , "stylesheets/netlogo-syntax"
                      ).map((x) => resolve(s"$x.css").toString)
     val cssTags = cssURLs.map(linkTag)
@@ -72,7 +72,7 @@ class Application @Inject() ( assets: Assets
                     , "addon/mode/simple"
                     , "addon/search/searchcursor"
                     , "addon/search/search"
-                    ).map((x) => resolve(s"lib/codemirror/$x.js").toString)
+                    ).map((x) => resolve(s"codemirror/$x.js").toString)
     val jsTags = jsURLs.map(scriptTag)
 
     val modeJSURLs = Seq( "keywords"

--- a/app/controllers/CompilerService.scala
+++ b/app/controllers/CompilerService.scala
@@ -292,8 +292,8 @@ private[controllers] trait RequestResultGenerator {
         "/public/stylesheets/ui-editor.css",
         "/public/stylesheets/netlogoweb.css",
         "/public/stylesheets/netlogo-syntax.css",
-        "/public/lib/codemirror/lib/codemirror.css",
-        "/public/lib/codemirror/addon/dialog/dialog.css"
+        "/public/codemirror/lib/codemirror.css",
+        "/public/codemirror/addon/dialog/dialog.css"
       )
 
     stylesheets map slurpURL mkString "\n"


### PR DESCRIPTION
While I was working on another issue, I found a curious bug.

Some paths to CodeMirror assets (mainly on the `/differences` page) were wrongly pointing to `/assets/lib/codemirror`, but the files are currently located only in `/assets/codemirror`. As a result, CodeMirror didn't load on the `/differences` page.

The interesting thing is, this apparently didn't cause a problem on the [production website](https://www.netlogoweb.org/docs/differences), because there were still some old files (last changed in 2016) in `/assets/lib/codemirror` on the server. So the library could load both from the old/wrong and the current/correct location.

Correct me, if I'm missing something. I checked and the issue is present even on a local prod build of a fresh clone of the `production` (and master of course too) branch of [NetLogo/Galapagos](https://github.com/NetLogo/Galapagos).