### PR TITLE
Bugfix: Fix some bugs caused by error-notification refactor

### DIFF
--- a/app/assets/javascripts/beak/widgets/event-traffic-control.coffee
+++ b/app/assets/javascripts/beak/widgets/event-traffic-control.coffee
@@ -147,6 +147,10 @@ window.controlEventTraffic = (controller) ->
     )
     return
 
+  showWidgetErrors = (widget) ->
+    if not widget.compilation.success
+      controller.reportError('compiler', widget.type, widget.compilation.messages)
+
   # (String, String, Any) => Boolean
   renameGlobal = (oldName, newName, value) ->
 
@@ -225,6 +229,7 @@ window.controlEventTraffic = (controller) ->
   ractive.on('check-action-keys'        , (_, event)         -> checkActionKeys(event))
   ractive.on('create-widget'            , (_, type, x, y)    -> createWidget(type, x, y))
   ractive.on('drop-overlay'             , (_, event)         -> dropOverlay())
+  ractive.on('*.show-widget-errors'     , (_, widget)        -> showWidgetErrors(widget))
   ractive.on('track-focus'              , (_, node)          -> trackFocus(node))
   ractive.on('*.refresh-chooser'        , (_, nada, chooser) -> refreshChooser(chooser))
   ractive.on('*.reject-duplicate-var'   , (_, varName)       -> rejectDupe(varName))

--- a/app/assets/javascripts/beak/widgets/event-traffic-control.coffee
+++ b/app/assets/javascripts/beak/widgets/event-traffic-control.coffee
@@ -140,7 +140,11 @@ window.controlEventTraffic = (controller) ->
 
   # (String) => Unit
   rejectDupe = (varName) ->
-    showErrors(["There is already a widget of a different type with a variable named '#{varName}'"])
+    controller.reportError(
+      'compiler',
+      'update-widget-value',
+      ["There is already a widget of a different type with a variable named '#{varName}'"]
+    )
     return
 
   # (String, String, Any) => Boolean
@@ -221,7 +225,6 @@ window.controlEventTraffic = (controller) ->
   ractive.on('check-action-keys'        , (_, event)         -> checkActionKeys(event))
   ractive.on('create-widget'            , (_, type, x, y)    -> createWidget(type, x, y))
   ractive.on('drop-overlay'             , (_, event)         -> dropOverlay())
-  ractive.on('show-errors'              , (_, event)         -> window.showErrors(event.context.compilation.messages))
   ractive.on('track-focus'              , (_, node)          -> trackFocus(node))
   ractive.on('*.refresh-chooser'        , (_, nada, chooser) -> refreshChooser(chooser))
   ractive.on('*.reject-duplicate-var'   , (_, varName)       -> rejectDupe(varName))

--- a/app/assets/javascripts/beak/widgets/ractives/monitor.coffee
+++ b/app/assets/javascripts/beak/widgets/ractives/monitor.coffee
@@ -100,7 +100,7 @@ window.RactiveMonitor = RactiveWidget.extend({
       """
       <div id="{{id}}" class="netlogo-widget netlogo-monitor netlogo-output {{classes}}"
            style="{{dims}} font-size: {{widget.fontSize}}px;">
-        <label class="netlogo-label {{errorClass}}" on-click="show-errors">{{widget.display || widget.source}}</label>
+        <label class="netlogo-label {{errorClass}}">{{widget.display || widget.source}}</label>
         <output class="netlogo-value">{{widget.currentValue}}</output>
       </div>
       """

--- a/app/assets/javascripts/beak/widgets/ractives/monitor.coffee
+++ b/app/assets/javascripts/beak/widgets/ractives/monitor.coffee
@@ -100,7 +100,9 @@ window.RactiveMonitor = RactiveWidget.extend({
       """
       <div id="{{id}}" class="netlogo-widget netlogo-monitor netlogo-output {{classes}}"
            style="{{dims}} font-size: {{widget.fontSize}}px;">
-        <label class="netlogo-label {{errorClass}}">{{widget.display || widget.source}}</label>
+        <label class="netlogo-label {{errorClass}}" on-click="['show-widget-errors', widget]">
+          {{widget.display || widget.source}}
+        </label>
         <output class="netlogo-value">{{widget.currentValue}}</output>
       </div>
       """

--- a/app/assets/javascripts/beak/widgets/ractives/slider.coffee
+++ b/app/assets/javascripts/beak/widgets/ractives/slider.coffee
@@ -171,7 +171,7 @@ window.RactiveSlider = RactiveWidget.extend({
                step="{{widget.stepValue}}" value="{{widget.currentValue}}"
                {{# isEditing }}disabled{{/}} />
         <div class="netlogo-slider-label">
-          <span class="netlogo-label">{{widget.display}}</span>
+          <span class="netlogo-label" on-click="['show-widget-errors', widget]">{{widget.display}}</span>
           <span class="netlogo-slider-value">
             <input type="number" on-change="reset-if-invalid"
                    style="width: {{widget.currentValue.toString().length + 3.0}}ch"

--- a/app/assets/javascripts/beak/widgets/ractives/slider.coffee
+++ b/app/assets/javascripts/beak/widgets/ractives/slider.coffee
@@ -171,7 +171,7 @@ window.RactiveSlider = RactiveWidget.extend({
                step="{{widget.stepValue}}" value="{{widget.currentValue}}"
                {{# isEditing }}disabled{{/}} />
         <div class="netlogo-slider-label">
-          <span class="netlogo-label" on-click="show-errors">{{widget.display}}</span>
+          <span class="netlogo-label">{{widget.display}}</span>
           <span class="netlogo-slider-value">
             <input type="number" on-change="reset-if-invalid"
                    style="width: {{widget.currentValue.toString().length + 3.0}}ch"

--- a/app/assets/javascripts/beak/widgets/widget-controller.coffee
+++ b/app/assets/javascripts/beak/widgets/widget-controller.coffee
@@ -18,7 +18,7 @@ class window.WidgetController
     widget    = Object.assign(base, mixin)
 
     id = Math.max(Object.keys(@ractive.get('widgetObj')).map(parseFloat)...) + 1
-    window.setUpWidget(widget, id, (=> @redraw(); @updateWidgets()))
+    window.setUpWidget(@reportError, widget, id, (=> @redraw(); @updateWidgets()))
 
     if widget.currentValue?
       world.observer.setGlobal(widget.variable, widget.currentValue)


### PR DESCRIPTION
Hello, I found (and fixed) some smaller bugs caused by the refactor of the error notification system, here is a summary:

**1. Cannot delete newly created widget:**

   When adding a new widget to a model and then deleting it, it would not get deleted, because of an exception:
   `widget-controller.js#removeWidgetById: this.ractive.get(...)[id] is undefined`.

   This error was fixed by passing the missing new parameter `reportError` to `setupWidget` in `widget-controller.coffee#createWidget`.

**2. Exception on duplicate widget vars**

   When multiple different widgets use the same variable, an error should be shown to the user, but now it throws an exception because of a missing function `showErrors` used in `event-traffic-control.coffee#rejectDupe`. (`showErrors` was replaced by the new error notification system.)

   To fix this, I used the new notification system instead of `showErrors`. I hope I used the new error notification system correctly, if there is a better way to do it, just let me know.

**3. Unneeded references to `showErrors`**

   While fixing the 2. issue, I also found one other reference to the now nonexistent `showErrors`, which is called from the `show-errors` event in `event-traffic-control.coffee`. The `show-errors` event is used in an on-click handler in `monitor.coffee` and `slider.coffee`.

   But `show-errors` was never called from the `on-click` handlers anyway. (To be fired from the `on-click` handlers, the event in `event-traffic-control.coffee` would need to be `'*.show-errors'` (with the wildcard star)).

   I don't think the click handlers are necessary for error reporting anymore, so I removed them and also the `show-errors` event, which should now be unnecessary. Do the on-click handlers referencing `show-errors` still have a purpose? I'm happy to edit the commit if this is the case.