### PR TITLE
Create initial CI workflow with GitHub Actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,30 @@
+name: CI
+on:
+  push:
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - run: git submodule update --init
+      - uses: actions/setup-java@v2
+        with:
+          distribution: 'zulu'
+          java-version: '17'
+      - run: yarn install
+      - run: yarn coffeelint
+
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - run: git submodule update --init
+      - uses: olafurpg/setup-scala@v13
+        id: setup-scala
+        with:
+          java-version: '11'
+      - run: sbt scalastyle
+      - run: sbt test


### PR DESCRIPTION
Adds an initial CI configuration using GitHub Actions with two jobs:
- A lint job using `yarn coffeelint`
- A build job using `sbt scalastyle` and `sbt test`

It was based on the current [Jenkins configuration](https://github.com/NetLogo/Galapagos/blob/master/Jenkinsfile). Staging and deployment haven't been implemented, but can be added later if desired. An [example run](https://github.com/EwoutH/Galapagos/actions/runs/1538670407) can be found on my fork.

GitHub Actions needs to be [enabled](https://github.com/NetLogo/Galapagos/actions) on this repository. 