### PR TITLE
Widget creation placement is off when window is scrolled - standalone html versions - a fix for this

### DIFF
--- a/app/assets/javascripts/beak/widgets/widget-controller.coffee
+++ b/app/assets/javascripts/beak/widgets/widget-controller.coffee
@@ -17,8 +17,8 @@ class WidgetController
   createWidget: (widgetType, x, y) ->
 
     rect      = document.querySelector('.netlogo-widget-container').getBoundingClientRect()
-    adjustedX = Math.round(x - rect.left)
-    adjustedY = Math.round(y - rect.top)
+    adjustedX = Math.round(x - (rect.left + window.scrollX ) )
+    adjustedY = Math.round(y - (rect.top + window.scrollY) )
     base      = { left: adjustedX, top: adjustedY, type: widgetType }
     mixin     = defaultWidgetMixinFor(widgetType, adjustedX, adjustedY, @_countByType)
     widget    = Object.assign(base, mixin)


### PR DESCRIPTION
Problem - if you scroll the window at all, the placement of newly created widgets is off, sometimes by a lot.

How to recreate:

1. Download any of the models as standalone HTML
2. Open it up
3. Go into authoring mode
4. Scroll down to the bottom of the editing area (depending on the model, if it does not have a lot of widgets, you may need to open up one the accordions e.g. code tab usually is quite large, and increases the size of the window, to really see the effect)
5. Right click on the editing area to bring up the context menu
6. Choose any of the widgets to add and then you will see it gets added further down than where you right clicked to bring up 

Here are some images from the virus model, doing this. This was is not too bad but on more complex models or if the widow is not full height, the widgets can be added below the window view, which for new users can be very confusing. 
![netl1](https://github.com/NetLogo/Galapagos/assets/4639722/eda82b26-718e-4176-b32b-56cdfb3282de)
![netl2](https://github.com/NetLogo/Galapagos/assets/4639722/023232fe-ec68-4da3-b2a4-7bfc6cbb639e)
![netl3](https://github.com/NetLogo/Galapagos/assets/4639722/0dd49c90-b23b-4b74-9558-c91edd670ac4)

**Solution**

I think I know why this is happening. The context menu collects the mouse pageX and pageY coordinates when it is activated. Those coordinates are then passed to the widgetController's createWidget function when a widget is chosen for creation. [https://github.com/NetLogo/Galapagos/blob/8f9c59abcb3f63612336e76e958256511f7a58b2/app/assets/javascripts/beak/widgets/widget-controller.coffee#L17](https://github.com/NetLogo/Galapagos/blob/8f9c59abcb3f63612336e76e958256511f7a58b2/app/assets/javascripts/beak/widgets/widget-controller.coffee#L17).

This code then gets the position of the .netlogo-widget-container element with getBoundingClientRect() and then minuses those left and top positions from pageX/pageY coordinates to get the position of the context menu relative to the .netlogo-widget-container element. 

```
 rect      = document.querySelector('.netlogo-widget-container').getBoundingClientRect()
 adjustedX = Math.round(x - rect.left)
 adjustedY = Math.round(y - rect.top)
```

The problem is that .getBoundingClientRect() gets positions relative to the viewport. So if the top of the .netlogo-widget-container element is above the viewport the resulting 'top' numbers will by negative (can also occur on the x-axis if there is horizontal scrolling). Then a double negative occurs ( y - - coordinate) and instead of taking away, the y coordinates are actually added and the resulting widget is placed much further down.

I think the solution is simple - add window.scrollY and window.scrollX to account for any scrolling i.e.

 adjustedX = Math.round(x - (rect.left + window.scrollX ))
 adjustedY = Math.round(y - (rect.top + window.scrollY ))
