### PR TITLE
Feature: Add a query parameter to override model title

### DIFF
--- a/app/assets/javascripts/pages/simulation.js
+++ b/app/assets/javascripts/pages/simulation.js
@@ -87,6 +87,9 @@ try {
     if (settings.workInProgress.enabled) {
       wipListener.setSession(globalThis.session);
     }
+    if (settings.title) {
+      globalThis.session.widgetController.ractive.set('modelTitle', settings.title);
+    }
     globalThis.session.widgetController.ractive.set('speed', settings.speed);
     globalThis.session.widgetController.ractive.set('isVertical', settings.useVerticalLayout);
     document.title = pageTitle(globalThis.session.modelTitle());

--- a/app/assets/javascripts/settings.coffee
+++ b/app/assets/javascripts/settings.coffee
@@ -29,6 +29,8 @@ class Settings
 
   useVerticalLayout: true
 
+  title: undefined # String
+
   speed: 0.0
 
   workInProgress: {
@@ -67,6 +69,9 @@ class Settings
 
     if params.has('tabs')
       @useVerticalLayout = not (params.get('tabs') is 'right')
+
+    if params.has('title')
+      @title = params.get('title')
 
     if params.has('speed')
       speedString = params.get('speed')


### PR DESCRIPTION
This will be useful in situations where it's not possible to control the filename of the model, which is currently used to set the model title. For example, Discourse automatically overrides the filename in the URL of uploaded attachments to the hash of the file.