### PR TITLE
Bugfix: Repeatedly plotting the same point causes weird extra lines

### DIFF
--- a/app/assets/javascripts/highcharts.coffee
+++ b/app/assets/javascripts/highcharts.coffee
@@ -246,8 +246,7 @@ class HighchartsOps extends PlotOps
 
       hcColor              = thisOps.colorToRGBString(color)
       series               = thisOps.penToSeries(pen)
-      series.options.color = hcColor
-      series.update(series.options, false)
+      series.update({color: hcColor}, false)
       thisOps._needsRedraw = true
 
       if not pen.isFake


### PR DESCRIPTION
Fixes NetLogo/Galapagos#393

- Plotting bug is caused by calling `series.update(series.options, false)` in updatePenColorwith full series.options object, rather than just the new color
- This is because `series.update()` merges the options passed to it with the existing ones, and it may also mutate the data in `series.options.data`. See [Highcharts Documentation: Series.update()](https://api.highcharts.com/class-reference/Highcharts.Series.html#update)
- Calling series.update({color: hcColor}, false) recolors the pen, and fixes the plotting issue
