### PR TITLE
[Fix] Patch numeric input not expanding constants

### DIFF
--- a/app/assets/javascripts/beak/widgets/ractives/input.coffee
+++ b/app/assets/javascripts/beak/widgets/ractives/input.coffee
@@ -215,8 +215,17 @@ RactiveInput = RactiveValueWidget.extend({
   validateValue: (newValue, oldValue) ->
     inputType = @get("widget.boxedValue.type")
     valueType = typeof(newValue)
+    
+    if inputType is "Number"
+      try
+        newValue = workspace.evalPrims.readFromString(newValue)
+        if newValue? and typeof(newValue) is "number"
+          @set("widget.currentValue", newValue)
+      catch
+        @resetValue("number", oldValue, 0)
+        return
 
-    if ([ "Color", "Number" ].includes(inputType) and valueType isnt "number")
+    if inputType is "Color" and valueType isnt "number"
       @resetValue("number", oldValue, 0)
       return
 
@@ -250,8 +259,8 @@ RactiveInput = RactiveValueWidget.extend({
         {{# widget.boxedValue.type === 'Number'}}
           <input
             class="netlogo-multiline-input"
-            type="number"
             value="{{internalValue}}"
+            data-type="number"
             lazy="true"
             on-change="['widget-value-change', widget.boxedValue.type]"
             {{# isEditing }}disabled{{/}}

--- a/public/stylesheets/widgets.css
+++ b/public/stylesheets/widgets.css
@@ -802,7 +802,7 @@ input[type=checkbox]:not(checked) ~ .netlogo-switcher-element > .netlogo-switche
   padding-inline: 0.2rem;
 }
 
-.netlogo-multiline-input[type=number] {
+.netlogo-multiline-input[data-type=number] {
   color: #a42f00;
 }
 


### PR DESCRIPTION
Original issue is [here](https://github.com/NetLogo/Galapagos/issues/435#event-19040373709).

## Situation breakdown
1. Evaluated the current behavior in NetLogo Web (live version and staging). Input fields are set to `type=number` and do not accept string values.
2. I tried to relax the input value by removing `type=number`. Setting the input to a non-numeric resulted in value being reset to 0.
3. Investigated the code and was able to identify [this code](https://github.com/NetLogo/Galapagos/blob/1c1e9f2a3a336ce8dd032b71b873fa0924d15cfa/app/assets/javascripts/beak/widgets/ractives/input.coffee#L215) as responsible for the reset.
4. Investigated NetLogo Desktop for its behavior implementation and identified [`InputType`](https://github.com/NetLogo/NetLogo/blob/4d68f24a7b1bc7f2fd1b26422e11a50e64197915/netlogo-gui/src/main/window/InputBox.scala#L719) to be responsible for value conversion.
5. Identified the compiler function `readNumberFromString` to be responsible for expanding constants.
6. Inspected Tortoise for a similar exposed function. Identified `Workspace.evalPrims.readFromString` as the candidate function.
7. Identified that `workspace` is globally accessible in Galapagos.
8. Patched the correct problem area.
9. Additionally, identified a styling issue related to the use of selector `type=number`. Replaced the `type` attribute with `data-type=number` for both the CSS selector and the HTML tag.
10. Ensured no regressions for number and color inputs.