### PR TITLE
[Fix] Change RactiveChooser to reference options using their indices not values (Fixes #444)

### DIFF
--- a/app/assets/javascripts/beak/widgets/ractives/chooser.coffee
+++ b/app/assets/javascripts/beak/widgets/ractives/chooser.coffee
@@ -154,12 +154,18 @@ RactiveChooser = RactiveValueWidget.extend({
 
   widgetType: "chooser"
 
-  observe: {
-    'widget.currentValue': () ->
-      widget        = @get('widget')
-      currentChoice = widget.choices.findIndex( (c) -> c is widget.currentValue )
-      @set('widget.currentChoice', if currentChoice >= 0 then currentChoice else 0)
-      return
+  on: {
+    'chooser-option-change': (event) ->
+      widget       = @get('widget')
+      selectedIdx  = parseInt(event.node.value)
+      selectedChoice = widget.choices[selectedIdx] or widget.choices[0]
+      isSelectedIdxValid = selectedIdx >= 0 and selectedIdx < widget.choices.length
+      if isSelectedIdxValid
+        @set('internalValue', selectedChoice)
+        @set('widget.currentChoice', if selectedIdx >= 0 then selectedIdx else 0)
+        @fire('widget-value-change')
+        return
+      return false
   }
 
   components: {
@@ -183,11 +189,11 @@ RactiveChooser = RactiveValueWidget.extend({
       <span class="netlogo-label">{{widget.display}}</span>
       <select
         class="netlogo-chooser-select"
-        value="{{internalValue}}"
-        on-change="widget-value-change"
+        value="{{widget.currentChoice}}"
+        on-change="chooser-option-change"
         {{# isEditing }} disabled{{/}} >
-        {{#widget.choices}}
-        <option class="netlogo-chooser-option" value="{{.}}">{{>literal}}</option>
+        {{#widget.choices:index}}
+        <option class="netlogo-chooser-option" value="{{index}}">{{>literal}}</option>
         {{/}}
       </select>
     </label>


### PR DESCRIPTION
## Relevant Issue
Fixes #444

## Steps to Remedy Issue
1. Set the `value` attribute on `<option>` in `RactiveChooser` to use the `index` position of the choice rather than its value.
2. Bound the `<select>` to `widget.currentChoice` instead of the widget's `internalValue`.
3. Removed the `widget.currentValue` observer responsible for setting the `widget.currentChoice` (index) value on the widget controller.
4. Added a new local event `chooser-option-change` and set it to update the `internalValue` and `widget.currentChoice` based on the new selected index before firing `widget-value-change` to the `WidgetController`.

## Consequences and Side Effects
RactiveChooser refers to options using their indices not values, making each value unique even when congruent or equivalent to other values.**

> ** Note that if you have choices `[1, 2, 3, 1]` and have the _**last**_ `1` selected then append a new choice to the list, say, `[1, 2, 3, 4, 1]`, the event system will change your choice from the _**last**_ `1` to the _**first**_ `1` in the current implementation. This applies to options that match in _value_ and _type_. Congruent values (but different types) do not exhibit this behavior.

## Tested Environments

- [x] Chrome Canary on MacOS 15.5 (ARM)
- [x] Firefox on MacOS 15.5 (ARM)
- [ ] Chromium on Ubuntu 24 LTS (ARM)
- [ ] Firefox on Ubuntu 24 LTS (ARM)
- [ ] Chromium on Windows 10/11 (ARM)
- [ ] Firefox on Windows 10/11 (ARM)
- [ ] Chromium on Windows 10/11 (64-bit)
- [ ] Firefox on Windows 10/11 (64-bit)