### PR TITLE
Fix typo on FAQ page

### DIFF
--- a/app/views/faq.scala.html
+++ b/app/views/faq.scala.html
@@ -240,7 +240,7 @@
     <li>Create a URL by using <code>https://netlogoweb.org/launch#myModelURL</code>.
       <ul><li>For example: <code>https://netlogoweb.org/launch#https://octocat.github.io/MyNetLogoModel.nlogox</code></li></ul>
       </li>
-    <li>Open the link in a web brwoser to test it out, you should see your model load in NetLogo Web and be ready to
+    <li>Open the link in a web browser to test it out, you should see your model load in NetLogo Web and be ready to
       go.</li>
   </ul>
 


### PR DESCRIPTION
See title, should be self-explanatory.