### PR TITLE
Bugfix: use a consistent coordinate space for CustomSlider drag

### DIFF
--- a/app/assets/javascripts/beak/widgets/ractives/subcomponent/custom-slider.coffee
+++ b/app/assets/javascripts/beak/widgets/ractives/subcomponent/custom-slider.coffee
@@ -81,26 +81,25 @@ RactiveCustomSlider = Ractive.extend({
 
     return
 
-  getClientPosition: (event) ->
+  getClientPosition: (event) -> # document-space coordinates
     switch @get('orientation')
-      when 'horizontal' then event.clientX or event.touches?[0]?.clientX
-      when 'vertical' then event.clientY or event.touches?[0]?.clientY
-      else event.clientX or event.touches?[0]?.clientX
+      when 'vertical' then (event.clientY or event.touches?[0]?.clientY) + window.scrollY
+      else (event.clientX or event.touches?[0]?.clientX) + window.scrollX
 
-  getSliderLength: (node) ->
+  getSliderLength: (node) -> # document-space coordinates
     rect = node.getBoundingClientRect()
     switch @get('orientation')
       when 'horizontal' then rect.width
       when 'vertical' then rect.height
       else throw new Error("Invalid orientation: #{@get('orientation')}")
 
-  getSliderLengthFromNode: (node) ->
+  getSliderLengthFromNode: (node) -> # object-space coordinates
     # Might look like a typo, but since rotation happens using
     # CSS, the bounding box changes but the node's offsetWidth/Height
     # do not. -Omar I. Aug 14, 2025
     return node.offsetWidth
 
-  getSliderStart: (node) ->
+  getSliderStart: (node) -> # document-space coordinates
     rect = node.getBoundingClientRect()
     switch @get('orientation')
       when 'horizontal' then rect.left + window.scrollX


### PR DESCRIPTION
## Issue
Sliders calculate click position incorrectly when NetLogo Web simulation runtime overflows. This issue requires the `iframe` itself to overflow, which does not happen on the `www.netlogoweb.org/launch` but happens on `www.netlogoweb.org/web`.

## Diagnosis
The function `getClientPosition` in `ReactiveCustomSlider` uses _viewport-space coordinates_ while `getSliderStart` and `getSliderLength` use _document-space coordinates_. Due to how `www.netlogoweb.org/launch` embeds the runtime simulation, those coordinate-spaces share the same basis and offset. This is not the case on `beta.modelingcommons.org` or when running `www.netlogoweb.org/web` in its own tab.

## Recreate
1. Open a model in `www.netlogoweb.org/web`
2. Go into authoring mode
3. Add a slider and push it outside of the window bounds 
4. Return to interactive mode
5. Scroll until you find the new slider
6. Click or drag along the slider

Expected behavior: slider snaps to mouse position on click and follows mouse on drag
Actual behavior: slider snaps to incorrect position, often at the extremes or by some noticeable offset from the mouse position

## Fix
Convert `getClientPosition` to document-space coordinates by adding the window scroll to its returned value.

Closes #459